### PR TITLE
infra: connection pooling, retry logic, structured errors, configurable SSL, logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+*.pyc
+.venv/

--- a/graylog-mcp/requirements.txt
+++ b/graylog-mcp/requirements.txt
@@ -1,2 +1,4 @@
 mcp[cli]>=1.0.0
 httpx>=0.27.0
+tenacity>=8.0.0
+python-dotenv>=1.0.0

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -4,29 +4,79 @@ Wraps the Graylog REST API and exposes search, streams, and alert endpoints
 as MCP tools for SOC workflows.
 """
 
+import logging
 import os
+from pathlib import Path
 
 import httpx
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
+logger = logging.getLogger("graylog-mcp")
 
 mcp = FastMCP("graylog")
 
 GRAYLOG_URL = os.environ.get("GRAYLOG_URL", "http://localhost:9000")
 GRAYLOG_API_TOKEN = os.environ.get("GRAYLOG_API_TOKEN", "")
+GRAYLOG_VERIFY_SSL = os.getenv("GRAYLOG_VERIFY_SSL", "true").lower() != "false"
+
+_http: httpx.Client | None = None
 
 
 def _client() -> httpx.Client:
-    return httpx.Client(
-        base_url=f"{GRAYLOG_URL}/api",
-        auth=(GRAYLOG_API_TOKEN, "token"),
-        headers={
-            "Accept": "application/json",
-            "X-Requested-By": "graylog-mcp",
-            "User-Agent": "graylog-mcp/1.0",
-        },
-        verify=False,
-        timeout=30,
-    )
+    global _http
+    if _http is None:
+        _http = httpx.Client(
+            base_url=f"{GRAYLOG_URL}/api",
+            auth=(GRAYLOG_API_TOKEN, "token"),
+            headers={
+                "Accept": "application/json",
+                "X-Requested-By": "graylog-mcp",
+                "User-Agent": "graylog-mcp/1.0",
+            },
+            verify=GRAYLOG_VERIFY_SSL,
+            timeout=30,
+        )
+    return _http
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _get(path: str, params: dict | None = None) -> dict:
+    logger.debug("GET %s params=%s", path, params)
+    r = _client().get(path, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _post(path: str, body: dict, params: dict | None = None) -> dict:
+    logger.debug("POST %s", path)
+    r = _client().post(path, json=body, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+def _err(e: Exception) -> dict:
+    if isinstance(e, httpx.HTTPStatusError):
+        return {
+            "error": f"HTTP {e.response.status_code}",
+            "url": str(e.request.url),
+            "detail": e.response.text[:500],
+        }
+    return {"error": type(e).__name__, "detail": str(e)}
 
 
 # ── Search ─────────────────────────────────────────────────────────────────
@@ -49,15 +99,15 @@ def search_relative(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "range": range_seconds, "limit": limit}
+    params: dict = {"query": query, "range": range_seconds, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/relative", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/relative", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -79,15 +129,15 @@ def search_absolute(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "from": from_time, "to": to_time, "limit": limit}
+    params: dict = {"query": query, "from": from_time, "to": to_time, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/absolute", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/absolute", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -107,15 +157,15 @@ def search_keyword(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "keyword": keyword, "limit": limit}
+    params: dict = {"query": query, "keyword": keyword, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/keyword", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/keyword", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -126,10 +176,10 @@ def get_message(message_id: str, index: str) -> dict:
         message_id: The message ID
         index: The Elasticsearch index containing the message
     """
-    with _client() as c:
-        r = c.get(f"/messages/{index}/{message_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/messages/{index}/{message_id}")
+    except Exception as e:
+        return _err(e)
 
 
 # ── Streams ────────────────────────────────────────────────────────────────
@@ -138,10 +188,10 @@ def get_message(message_id: str, index: str) -> dict:
 @mcp.tool()
 def list_streams() -> dict:
     """List all streams configured in Graylog."""
-    with _client() as c:
-        r = c.get("/streams")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/streams")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -151,10 +201,10 @@ def get_stream(stream_id: str) -> dict:
     Args:
         stream_id: The stream ID
     """
-    with _client() as c:
-        r = c.get(f"/streams/{stream_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/streams/{stream_id}")
+    except Exception as e:
+        return _err(e)
 
 
 # ── Alerts / Events ───────────────────────────────────────────────────────
@@ -175,27 +225,27 @@ def search_events(
         page: Page number (default: 1)
         per_page: Results per page (default: 50)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/events/search",
-            json={
+            {
                 "query": query,
                 "timerange": {"type": "relative", "range": timerange_from},
                 "page": page,
                 "per_page": per_page,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
 def list_event_definitions() -> dict:
     """List all event/alert definitions configured in Graylog."""
-    with _client() as c:
-        r = c.get("/events/definitions")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/events/definitions")
+    except Exception as e:
+        return _err(e)
 
 
 # ── System ─────────────────────────────────────────────────────────────────
@@ -204,19 +254,19 @@ def list_event_definitions() -> dict:
 @mcp.tool()
 def system_overview() -> dict:
     """Get Graylog system overview (version, cluster, status)."""
-    with _client() as c:
-        r = c.get("/system")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/system")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
 def list_inputs() -> dict:
     """List all configured inputs in Graylog."""
-    with _client() as c:
-        r = c.get("/system/inputs")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/system/inputs")
+    except Exception as e:
+        return _err(e)
 
 
 if __name__ == "__main__":

--- a/iris-mcp/requirements.txt
+++ b/iris-mcp/requirements.txt
@@ -1,2 +1,4 @@
 mcp[cli]>=1.0.0
 httpx>=0.27.0
+tenacity>=8.0.0
+python-dotenv>=1.0.0

--- a/iris-mcp/server.py
+++ b/iris-mcp/server.py
@@ -1,29 +1,99 @@
 """DFIR-IRIS MCP Server.
 
-Wraps the DFIR-IRIS REST API and exposes case management endpoints as MCP tools.
+Wraps the DFIR-IRIS REST API and exposes case management, IOC, asset, timeline,
+notes, and investigation tools as MCP tools for SOC workflows.
 """
 
+import logging
 import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import httpx
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
+logger = logging.getLogger("iris-mcp")
 
 mcp = FastMCP("dfir-iris")
 
 IRIS_URL = os.environ.get("IRIS_URL", "https://localhost:8443")
 IRIS_API_KEY = os.environ.get("IRIS_API_KEY", "")
+IRIS_VERIFY_SSL = os.getenv("IRIS_VERIFY_SSL", "false").lower() != "false"
+
+if not IRIS_API_KEY:
+    logger.warning("IRIS_API_KEY is not set — all API calls will fail with 401")
+
+_http: httpx.Client | None = None
 
 
 def _client() -> httpx.Client:
-    return httpx.Client(
-        base_url=IRIS_URL,
-        headers={
-            "Authorization": f"Bearer {IRIS_API_KEY}",
-            "User-Agent": "iris-mcp/1.0",
-        },
-        verify=False,
-        timeout=30,
-    )
+    global _http
+    if _http is None:
+        _http = httpx.Client(
+            base_url=IRIS_URL,
+            headers={
+                "Authorization": f"Bearer {IRIS_API_KEY}",
+                "User-Agent": "iris-mcp/1.0",
+                "Content-Type": "application/json",
+            },
+            verify=IRIS_VERIFY_SSL,
+            timeout=30,
+        )
+    return _http
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _get(path: str, params: dict | None = None) -> dict:
+    logger.debug("GET %s params=%s", path, params)
+    r = _client().get(path, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _post(path: str, params: dict | None = None, body: dict | None = None) -> dict:
+    logger.debug("POST %s", path)
+    r = _client().post(path, params=params, json=body or {})
+    r.raise_for_status()
+    return r.json()
+
+
+def _err(e: Exception) -> dict:
+    if isinstance(e, httpx.HTTPStatusError):
+        return {
+            "error": f"HTTP {e.response.status_code}",
+            "url": str(e.request.url),
+            "detail": e.response.text[:500],
+        }
+    return {"error": type(e).__name__, "detail": str(e)}
+
+
+def _parse_since(since: str) -> datetime | None:
+    """Parse a human time delta string into a UTC cutoff datetime."""
+    if not since:
+        return None
+    since = since.strip().lower()
+    units = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
+    if since[-1] in units and since[:-1].isdigit():
+        return datetime.now(timezone.utc) - timedelta(**{units[since[-1]]: int(since[:-1])})
+    try:
+        return datetime.fromisoformat(since).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
 
 
 # ── Cases ──────────────────────────────────────────────────────────────────
@@ -32,10 +102,10 @@ def _client() -> httpx.Client:
 @mcp.tool()
 def list_cases() -> dict:
     """List all cases in DFIR-IRIS."""
-    with _client() as c:
-        r = c.get("/manage/cases/list")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/manage/cases/list")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -45,10 +115,10 @@ def get_case(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get(f"/manage/cases/{case_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/manage/cases/{case_id}")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -66,18 +136,18 @@ def create_case(
         case_customer: Customer ID (default: 1)
         case_soc_id: SOC ticket ID (optional)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/manage/cases/add",
-            json={
+            body={
                 "case_name": case_name,
                 "case_description": case_description,
                 "case_customer": case_customer,
                 "case_soc_id": case_soc_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── IOCs ───────────────────────────────────────────────────────────────────
@@ -85,15 +155,15 @@ def create_case(
 
 @mcp.tool()
 def list_iocs(case_id: int) -> dict:
-    """List all IOCs (Indicators of Compromise) for a case.
+    """List all IOCs for a case.
 
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/ioc/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/ioc/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -107,25 +177,25 @@ def add_ioc(
     """Add an IOC to a case.
 
     Args:
-        case_id: The case ID to add the IOC to
+        case_id: The case ID
         ioc_value: The IOC value (IP, hash, domain, etc.)
-        ioc_type_id: Type of IOC (1=hash, 2=IP, 3=domain, etc.)
+        ioc_type_id: IOC type (1=hash, 2=IP, 3=domain, 4=URL, 5=email, 6=filename, 7=hostname)
         ioc_description: Description of the IOC
         ioc_tlp_id: TLP level (1=red, 2=amber, 3=green, 4=white)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/ioc/add",
             params={"cid": case_id},
-            json={
+            body={
                 "ioc_value": ioc_value,
                 "ioc_type_id": ioc_type_id,
                 "ioc_description": ioc_description,
                 "ioc_tlp_id": ioc_tlp_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Assets ─────────────────────────────────────────────────────────────────
@@ -138,10 +208,10 @@ def list_assets(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/assets/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/assets/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -157,23 +227,23 @@ def add_asset(
     Args:
         case_id: The case ID
         asset_name: Name or hostname of the asset
-        asset_type_id: Asset type (1=account, 2=firewall, 3=linux-server, 4=linux-workstation, 5=mac, 9=windows-server, 10=windows-workstation, etc.)
+        asset_type_id: Asset type (1=account, 2=firewall, 3=linux-server, 4=linux-workstation, 5=mac, 9=windows-server, 10=windows-workstation)
         asset_description: Description of the asset
         asset_compromise_status_id: Compromise status (0=unknown, 1=compromised, 2=not compromised, 3=remediated)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/assets/add",
             params={"cid": case_id},
-            json={
+            body={
                 "asset_name": asset_name,
                 "asset_type_id": asset_type_id,
                 "asset_description": asset_description,
                 "asset_compromise_status_id": asset_compromise_status_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Timeline ───────────────────────────────────────────────────────────────
@@ -186,10 +256,10 @@ def list_timeline(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/timeline/events/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/timeline/events/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -205,23 +275,23 @@ def add_timeline_event(
     Args:
         case_id: The case ID
         event_title: Title of the event
-        event_date: Date/time of the event (ISO format)
-        event_content: Detailed description
+        event_date: Date/time of the event (ISO 8601 format, e.g. 2024-01-15T10:00:00)
+        event_content: Detailed description (Markdown supported)
         event_category_id: Category ID for the event
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/timeline/events/add",
             params={"cid": case_id},
-            json={
+            body={
                 "event_title": event_title,
                 "event_date": event_date,
                 "event_content": event_content,
                 "event_category_id": event_category_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Notes ──────────────────────────────────────────────────────────────────
@@ -234,10 +304,10 @@ def list_notes_groups(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/notes/groups/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/notes/groups/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -255,18 +325,18 @@ def add_note(
         note_content: Markdown content of the note
         group_id: Note group ID to add the note to
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/notes/add",
             params={"cid": case_id},
-            json={
+            body={
                 "note_title": note_title,
                 "note_content": note_content,
                 "group_id": group_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 if __name__ == "__main__":

--- a/iris-mcp/server.py
+++ b/iris-mcp/server.py
@@ -22,7 +22,7 @@ mcp = FastMCP("dfir-iris")
 
 IRIS_URL = os.environ.get("IRIS_URL", "https://localhost:8443")
 IRIS_API_KEY = os.environ.get("IRIS_API_KEY", "")
-IRIS_VERIFY_SSL = os.getenv("IRIS_VERIFY_SSL", "false").lower() != "false"
+IRIS_VERIFY_SSL = os.getenv("IRIS_VERIFY_SSL", "true").lower() != "false"
 
 if not IRIS_API_KEY:
     logger.warning("IRIS_API_KEY is not set — all API calls will fail with 401")


### PR DESCRIPTION
## Summary

Reliability and observability improvements shared by both `graylog-mcp` and `iris-mcp`. No new tools — this is pure infrastructure, reviewable on its own.

- **Connection pooling**: persistent `httpx.Client` singleton instead of creating a new client per tool call
- **Retry logic**: `@retry` decorator (tenacity) on `_get`/`_post` — up to 3 attempts on `TransportError` with exponential backoff
- **Structured errors**: `_err()` helper returns `{error, url, detail}` dicts instead of raising unhandled exceptions to the MCP caller
- **Configurable SSL**: `GRAYLOG_VERIFY_SSL` (defaults `true`) and `IRIS_VERIFY_SSL` (defaults `true`) — set to `false` to bypass cert validation on trusted internal networks with self-signed certs
- **Logging**: `LOG_LEVEL` env var wired to Python `logging`; per-server named logger
- **dotenv**: `python-dotenv` loads a root `.env` at startup for local dev
- **`.gitignore`**: `.env`, `__pycache__`, `*.pyc`, `.venv`

## Test plan

- [ ] Start each server and confirm tools still respond correctly (no regressions)
- [ ] Set `LOG_LEVEL=DEBUG` and verify request logs appear
- [ ] Set `GRAYLOG_VERIFY_SSL=false` / `IRIS_VERIFY_SSL=false` on a self-signed instance and confirm it connects
- [ ] Simulate a transient network error and confirm the retry fires (3 attempts, exponential backoff)
- [ ] Confirm an HTTP 4xx returns a structured `{"error": "HTTP 4xx", ...}` dict instead of raising

🤖 Generated with [Claude Code](https://claude.com/claude-code)