### PR TITLE
iris-mcp: case filtering, case summary, global IOC search, status management, notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+*.pyc
+.venv/

--- a/graylog-mcp/requirements.txt
+++ b/graylog-mcp/requirements.txt
@@ -1,2 +1,4 @@
 mcp[cli]>=1.0.0
 httpx>=0.27.0
+tenacity>=8.0.0
+python-dotenv>=1.0.0

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -4,29 +4,79 @@ Wraps the Graylog REST API and exposes search, streams, and alert endpoints
 as MCP tools for SOC workflows.
 """
 
+import logging
 import os
+from pathlib import Path
 
 import httpx
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
+logger = logging.getLogger("graylog-mcp")
 
 mcp = FastMCP("graylog")
 
 GRAYLOG_URL = os.environ.get("GRAYLOG_URL", "http://localhost:9000")
 GRAYLOG_API_TOKEN = os.environ.get("GRAYLOG_API_TOKEN", "")
+GRAYLOG_VERIFY_SSL = os.getenv("GRAYLOG_VERIFY_SSL", "true").lower() != "false"
+
+_http: httpx.Client | None = None
 
 
 def _client() -> httpx.Client:
-    return httpx.Client(
-        base_url=f"{GRAYLOG_URL}/api",
-        auth=(GRAYLOG_API_TOKEN, "token"),
-        headers={
-            "Accept": "application/json",
-            "X-Requested-By": "graylog-mcp",
-            "User-Agent": "graylog-mcp/1.0",
-        },
-        verify=False,
-        timeout=30,
-    )
+    global _http
+    if _http is None:
+        _http = httpx.Client(
+            base_url=f"{GRAYLOG_URL}/api",
+            auth=(GRAYLOG_API_TOKEN, "token"),
+            headers={
+                "Accept": "application/json",
+                "X-Requested-By": "graylog-mcp",
+                "User-Agent": "graylog-mcp/1.0",
+            },
+            verify=GRAYLOG_VERIFY_SSL,
+            timeout=30,
+        )
+    return _http
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _get(path: str, params: dict | None = None) -> dict:
+    logger.debug("GET %s params=%s", path, params)
+    r = _client().get(path, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _post(path: str, body: dict, params: dict | None = None) -> dict:
+    logger.debug("POST %s", path)
+    r = _client().post(path, json=body, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+def _err(e: Exception) -> dict:
+    if isinstance(e, httpx.HTTPStatusError):
+        return {
+            "error": f"HTTP {e.response.status_code}",
+            "url": str(e.request.url),
+            "detail": e.response.text[:500],
+        }
+    return {"error": type(e).__name__, "detail": str(e)}
 
 
 # ── Search ─────────────────────────────────────────────────────────────────
@@ -49,15 +99,15 @@ def search_relative(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "range": range_seconds, "limit": limit}
+    params: dict = {"query": query, "range": range_seconds, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/relative", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/relative", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -79,15 +129,15 @@ def search_absolute(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "from": from_time, "to": to_time, "limit": limit}
+    params: dict = {"query": query, "from": from_time, "to": to_time, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/absolute", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/absolute", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -107,15 +157,15 @@ def search_keyword(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "keyword": keyword, "limit": limit}
+    params: dict = {"query": query, "keyword": keyword, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/keyword", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/keyword", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -126,10 +176,10 @@ def get_message(message_id: str, index: str) -> dict:
         message_id: The message ID
         index: The Elasticsearch index containing the message
     """
-    with _client() as c:
-        r = c.get(f"/messages/{index}/{message_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/messages/{index}/{message_id}")
+    except Exception as e:
+        return _err(e)
 
 
 # ── Streams ────────────────────────────────────────────────────────────────
@@ -138,10 +188,10 @@ def get_message(message_id: str, index: str) -> dict:
 @mcp.tool()
 def list_streams() -> dict:
     """List all streams configured in Graylog."""
-    with _client() as c:
-        r = c.get("/streams")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/streams")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -151,10 +201,10 @@ def get_stream(stream_id: str) -> dict:
     Args:
         stream_id: The stream ID
     """
-    with _client() as c:
-        r = c.get(f"/streams/{stream_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/streams/{stream_id}")
+    except Exception as e:
+        return _err(e)
 
 
 # ── Alerts / Events ───────────────────────────────────────────────────────
@@ -175,27 +225,27 @@ def search_events(
         page: Page number (default: 1)
         per_page: Results per page (default: 50)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/events/search",
-            json={
+            {
                 "query": query,
                 "timerange": {"type": "relative", "range": timerange_from},
                 "page": page,
                 "per_page": per_page,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
 def list_event_definitions() -> dict:
     """List all event/alert definitions configured in Graylog."""
-    with _client() as c:
-        r = c.get("/events/definitions")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/events/definitions")
+    except Exception as e:
+        return _err(e)
 
 
 # ── System ─────────────────────────────────────────────────────────────────
@@ -204,19 +254,19 @@ def list_event_definitions() -> dict:
 @mcp.tool()
 def system_overview() -> dict:
     """Get Graylog system overview (version, cluster, status)."""
-    with _client() as c:
-        r = c.get("/system")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/system")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
 def list_inputs() -> dict:
     """List all configured inputs in Graylog."""
-    with _client() as c:
-        r = c.get("/system/inputs")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/system/inputs")
+    except Exception as e:
+        return _err(e)
 
 
 if __name__ == "__main__":

--- a/iris-mcp/requirements.txt
+++ b/iris-mcp/requirements.txt
@@ -1,2 +1,4 @@
 mcp[cli]>=1.0.0
 httpx>=0.27.0
+tenacity>=8.0.0
+python-dotenv>=1.0.0

--- a/iris-mcp/server.py
+++ b/iris-mcp/server.py
@@ -1,11 +1,12 @@
 """DFIR-IRIS MCP Server.
 
-Wraps the DFIR-IRIS REST API and exposes case management, IOC, asset, timeline,
-notes, and investigation tools as MCP tools for SOC workflows.
+Wraps the DFIR-IRIS REST API and exposes case management, IOC, asset, and timeline
+tools as MCP tools for SOC workflows.
 """
 
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -22,7 +23,7 @@ mcp = FastMCP("dfir-iris")
 
 IRIS_URL = os.environ.get("IRIS_URL", "https://localhost:8443")
 IRIS_API_KEY = os.environ.get("IRIS_API_KEY", "")
-IRIS_VERIFY_SSL = os.getenv("IRIS_VERIFY_SSL", "false").lower() != "false"
+IRIS_VERIFY_SSL = os.getenv("IRIS_VERIFY_SSL", "true").lower() != "false"
 
 if not IRIS_API_KEY:
     logger.warning("IRIS_API_KEY is not set — all API calls will fail with 401")
@@ -100,10 +101,51 @@ def _parse_since(since: str) -> datetime | None:
 
 
 @mcp.tool()
-def list_cases() -> dict:
-    """List all cases in DFIR-IRIS."""
+def list_cases(
+    status: str = "open",
+    since: str = "",
+    limit: int = 50,
+) -> dict:
+    """List DFIR-IRIS cases with optional filtering.
+
+    Args:
+        status: Filter by case status — "open", "closed", or "all" (default: "open")
+        since: Only return cases opened after this time window.
+               Accepts: "30m", "1h", "6h", "24h", "7d", "30d", or ISO datetime string.
+               Leave empty for all time.
+        limit: Maximum number of cases to return (default: 50)
+    """
     try:
-        return _get("/manage/cases/list")
+        result = _get("/manage/cases/list")
+        cases = result.get("data", result) if isinstance(result, dict) else result
+        if isinstance(cases, dict):
+            cases = cases.get("cases", [])
+
+        if status == "open":
+            cases = [c for c in cases if not c.get("case_close_date")]
+        elif status == "closed":
+            cases = [c for c in cases if c.get("case_close_date")]
+
+        cutoff = _parse_since(since)
+        if cutoff:
+            filtered = []
+            for c in cases:
+                raw = c.get("case_open_date") or c.get("open_date", "")
+                if raw:
+                    try:
+                        opened = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+                        if opened.tzinfo is None:
+                            opened = opened.replace(tzinfo=timezone.utc)
+                        if opened >= cutoff:
+                            filtered.append(c)
+                    except ValueError:
+                        filtered.append(c)
+                else:
+                    filtered.append(c)
+            cases = filtered
+
+        cases = cases[:limit]
+        return {"total": len(cases), "cases": cases}
     except Exception as e:
         return _err(e)
 
@@ -119,6 +161,34 @@ def get_case(case_id: int) -> dict:
         return _get(f"/manage/cases/{case_id}")
     except Exception as e:
         return _err(e)
+
+
+@mcp.tool()
+def get_case_summary(case_id: int) -> dict:
+    """Get a full summary of a case in one call: details, IOCs, assets, and timeline.
+
+    Fetches all four in parallel and merges into a single response.
+    Useful for the analyse-case skill which otherwise needs 4+ sequential calls.
+
+    Args:
+        case_id: The numeric case ID
+    """
+    def fetch(fn, *args):
+        try:
+            return fn(*args)
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = {
+            "case":     pool.submit(fetch, _get, f"/manage/cases/{case_id}"),
+            "iocs":     pool.submit(fetch, _get, "/case/ioc/list", {"cid": case_id}),
+            "assets":   pool.submit(fetch, _get, "/case/assets/list", {"cid": case_id}),
+            "timeline": pool.submit(fetch, _get, "/case/timeline/events/list", {"cid": case_id}),
+        }
+        results = {key: f.result() for key, f in futures.items()}
+
+    return results
 
 
 @mcp.tool()
@@ -162,6 +232,70 @@ def list_iocs(case_id: int) -> dict:
     """
     try:
         return _get("/case/ioc/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def search_ioc_global(
+    value: str,
+    status: str = "open",
+    since: str = "",
+) -> dict:
+    """Search for an IOC value across all cases in one call.
+
+    Instead of looping list_iocs() per case (N sequential requests), this tool
+    fetches the filtered case pool and fans out IOC lookups in parallel using a
+    thread pool — much faster for large case volumes.
+
+    Args:
+        value: IOC value to search for (IP, hash, domain, username, etc.) — case-insensitive substring match
+        status: Only search cases with this status — "open", "closed", or "all" (default: "open")
+        since: Narrow the case pool by time window (e.g. "24h", "7d") — same syntax as list_cases
+    """
+    try:
+        pool_result = list_cases(status=status, since=since, limit=200)
+        if "error" in pool_result:
+            return pool_result
+        cases = pool_result.get("cases", [])
+
+        matches = []
+        errors = []
+        value_lower = value.lower()
+
+        def check_case(case):
+            cid = case.get("case_id") or case.get("id")
+            if not cid:
+                return []
+            try:
+                result = _get("/case/ioc/list", {"cid": cid})
+                iocs = result.get("data", result)
+                if isinstance(iocs, dict):
+                    iocs = iocs.get("iocs", [])
+                return [
+                    {
+                        "case_id": cid,
+                        "case_name": case.get("case_name", ""),
+                        "ioc_value": ioc.get("ioc_value", ""),
+                        "ioc_type": ioc.get("ioc_type_name", ""),
+                        "ioc_description": ioc.get("ioc_description", ""),
+                        "ioc_tlp": ioc.get("ioc_tlp_name", ""),
+                    }
+                    for ioc in (iocs if isinstance(iocs, list) else [])
+                    if value_lower in str(ioc.get("ioc_value", "")).lower()
+                ]
+            except Exception as exc:
+                errors.append(f"case {cid}: {exc}")
+                return []
+
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            for result in pool.map(check_case, cases):
+                matches.extend(result)
+
+        out = {"query": value, "total_matches": len(matches), "matches": matches}
+        if errors:
+            out["errors"] = errors
+        return out
     except Exception as e:
         return _err(e)
 

--- a/iris-mcp/server.py
+++ b/iris-mcp/server.py
@@ -1,29 +1,99 @@
 """DFIR-IRIS MCP Server.
 
-Wraps the DFIR-IRIS REST API and exposes case management endpoints as MCP tools.
+Wraps the DFIR-IRIS REST API and exposes case management, IOC, asset, timeline,
+notes, and investigation tools as MCP tools for SOC workflows.
 """
 
+import logging
 import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import httpx
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
+logger = logging.getLogger("iris-mcp")
 
 mcp = FastMCP("dfir-iris")
 
 IRIS_URL = os.environ.get("IRIS_URL", "https://localhost:8443")
 IRIS_API_KEY = os.environ.get("IRIS_API_KEY", "")
+IRIS_VERIFY_SSL = os.getenv("IRIS_VERIFY_SSL", "false").lower() != "false"
+
+if not IRIS_API_KEY:
+    logger.warning("IRIS_API_KEY is not set — all API calls will fail with 401")
+
+_http: httpx.Client | None = None
 
 
 def _client() -> httpx.Client:
-    return httpx.Client(
-        base_url=IRIS_URL,
-        headers={
-            "Authorization": f"Bearer {IRIS_API_KEY}",
-            "User-Agent": "iris-mcp/1.0",
-        },
-        verify=False,
-        timeout=30,
-    )
+    global _http
+    if _http is None:
+        _http = httpx.Client(
+            base_url=IRIS_URL,
+            headers={
+                "Authorization": f"Bearer {IRIS_API_KEY}",
+                "User-Agent": "iris-mcp/1.0",
+                "Content-Type": "application/json",
+            },
+            verify=IRIS_VERIFY_SSL,
+            timeout=30,
+        )
+    return _http
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _get(path: str, params: dict | None = None) -> dict:
+    logger.debug("GET %s params=%s", path, params)
+    r = _client().get(path, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _post(path: str, params: dict | None = None, body: dict | None = None) -> dict:
+    logger.debug("POST %s", path)
+    r = _client().post(path, params=params, json=body or {})
+    r.raise_for_status()
+    return r.json()
+
+
+def _err(e: Exception) -> dict:
+    if isinstance(e, httpx.HTTPStatusError):
+        return {
+            "error": f"HTTP {e.response.status_code}",
+            "url": str(e.request.url),
+            "detail": e.response.text[:500],
+        }
+    return {"error": type(e).__name__, "detail": str(e)}
+
+
+def _parse_since(since: str) -> datetime | None:
+    """Parse a human time delta string into a UTC cutoff datetime."""
+    if not since:
+        return None
+    since = since.strip().lower()
+    units = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
+    if since[-1] in units and since[:-1].isdigit():
+        return datetime.now(timezone.utc) - timedelta(**{units[since[-1]]: int(since[:-1])})
+    try:
+        return datetime.fromisoformat(since).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
 
 
 # ── Cases ──────────────────────────────────────────────────────────────────
@@ -32,10 +102,10 @@ def _client() -> httpx.Client:
 @mcp.tool()
 def list_cases() -> dict:
     """List all cases in DFIR-IRIS."""
-    with _client() as c:
-        r = c.get("/manage/cases/list")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/manage/cases/list")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -45,10 +115,10 @@ def get_case(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get(f"/manage/cases/{case_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/manage/cases/{case_id}")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -66,18 +136,18 @@ def create_case(
         case_customer: Customer ID (default: 1)
         case_soc_id: SOC ticket ID (optional)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/manage/cases/add",
-            json={
+            body={
                 "case_name": case_name,
                 "case_description": case_description,
                 "case_customer": case_customer,
                 "case_soc_id": case_soc_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── IOCs ───────────────────────────────────────────────────────────────────
@@ -85,15 +155,15 @@ def create_case(
 
 @mcp.tool()
 def list_iocs(case_id: int) -> dict:
-    """List all IOCs (Indicators of Compromise) for a case.
+    """List all IOCs for a case.
 
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/ioc/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/ioc/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -107,25 +177,25 @@ def add_ioc(
     """Add an IOC to a case.
 
     Args:
-        case_id: The case ID to add the IOC to
+        case_id: The case ID
         ioc_value: The IOC value (IP, hash, domain, etc.)
-        ioc_type_id: Type of IOC (1=hash, 2=IP, 3=domain, etc.)
+        ioc_type_id: IOC type (1=hash, 2=IP, 3=domain, 4=URL, 5=email, 6=filename, 7=hostname)
         ioc_description: Description of the IOC
         ioc_tlp_id: TLP level (1=red, 2=amber, 3=green, 4=white)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/ioc/add",
             params={"cid": case_id},
-            json={
+            body={
                 "ioc_value": ioc_value,
                 "ioc_type_id": ioc_type_id,
                 "ioc_description": ioc_description,
                 "ioc_tlp_id": ioc_tlp_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Assets ─────────────────────────────────────────────────────────────────
@@ -138,10 +208,10 @@ def list_assets(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/assets/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/assets/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -157,23 +227,23 @@ def add_asset(
     Args:
         case_id: The case ID
         asset_name: Name or hostname of the asset
-        asset_type_id: Asset type (1=account, 2=firewall, 3=linux-server, 4=linux-workstation, 5=mac, 9=windows-server, 10=windows-workstation, etc.)
+        asset_type_id: Asset type (1=account, 2=firewall, 3=linux-server, 4=linux-workstation, 5=mac, 9=windows-server, 10=windows-workstation)
         asset_description: Description of the asset
         asset_compromise_status_id: Compromise status (0=unknown, 1=compromised, 2=not compromised, 3=remediated)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/assets/add",
             params={"cid": case_id},
-            json={
+            body={
                 "asset_name": asset_name,
                 "asset_type_id": asset_type_id,
                 "asset_description": asset_description,
                 "asset_compromise_status_id": asset_compromise_status_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Timeline ───────────────────────────────────────────────────────────────
@@ -186,10 +256,10 @@ def list_timeline(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/timeline/events/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/timeline/events/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -205,23 +275,23 @@ def add_timeline_event(
     Args:
         case_id: The case ID
         event_title: Title of the event
-        event_date: Date/time of the event (ISO format)
-        event_content: Detailed description
+        event_date: Date/time of the event (ISO 8601 format, e.g. 2024-01-15T10:00:00)
+        event_content: Detailed description (Markdown supported)
         event_category_id: Category ID for the event
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/timeline/events/add",
             params={"cid": case_id},
-            json={
+            body={
                 "event_title": event_title,
                 "event_date": event_date,
                 "event_content": event_content,
                 "event_category_id": event_category_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Notes ──────────────────────────────────────────────────────────────────
@@ -234,10 +304,10 @@ def list_notes_groups(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/notes/groups/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/notes/groups/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -255,18 +325,18 @@ def add_note(
         note_content: Markdown content of the note
         group_id: Note group ID to add the note to
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/notes/add",
             params={"cid": case_id},
-            json={
+            body={
                 "note_title": note_title,
                 "note_content": note_content,
                 "group_id": group_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Depends on #3 (infra) — merge that first for a clean diff.**

New tools for `iris-mcp`. Focus is on composite operations that go beyond what a raw API wrapper provides — the 1:1 endpoint wrappers (`close_case`, `update_case_status`, `get_notes`) are tracked for auto-generation from IRIS's OpenAPI spec in #2 and are not included here.

**Case management**:
- `list_cases`: now accepts `status` (open/closed/all), `since` time window (e.g. "24h", "7d"), and `limit` — prevents the LLM from pulling all cases on busy servers
- `get_case_summary`: fetches case details + IOCs + assets + timeline in parallel (4 threads) — replaces 4+ sequential calls in the `analyse-case` skill

**Global IOC search**:
- `search_ioc_global`: fan-out IOC lookup across all cases in parallel (10-thread pool) — much faster than calling `list_iocs()` per case; reuses `list_cases` filters to keep the case pool bounded

**Helper**: `_parse_since()` converts "30m"/"1h"/"7d" shorthand or ISO datetime strings to UTC cutoff datetimes.

## Test plan

- [ ] `list_cases(status="open", since="24h")` returns only open cases from last 24h
- [ ] `list_cases(status="closed")` excludes open cases
- [ ] `list_cases(limit=10)` returns at most 10 results
- [ ] `get_case_summary(case_id)` returns case + iocs + assets + timeline in one call
- [ ] `search_ioc_global("1.2.3.4")` finds the IOC across multiple cases
- [ ] `search_ioc_global("1.2.3.4", since="7d")` limits the case pool to the last 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)