### PR TITLE
skills: graylog-hunt and investigate SKILL.md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+*.pyc
+.venv/

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -44,15 +44,15 @@ docker run -i --rm --network host \
 
 ## Tools
 
-### Search (Graylog 6.x — `views/search/sync`)
+### Search & Aggregation (Graylog 6.x — `views/search/sync`)
 
-> Use these tools on Graylog 6.x. The legacy search tools below return 0 results on 6.x.
+> Use these tools on Graylog 6.x. The legacy tools below return 0 results on 6.x.
+> Tool names and parameters match the [native Graylog 6.1+ MCP server](https://github.com/Graylog2/graylog2-server) for skill portability.
 
 | Tool | Description |
 |---|---|
-| `search_sync` | Search messages — replaces `search_relative`/`search_absolute` for Graylog 6.x |
-| `aggregate_terms` | Top-N field value counts via pivot — replaces `search_terms` for Graylog 6.x |
-| `aggregate_histogram` | Message count over time via pivot — replaces `search_histogram` for Graylog 6.x |
+| `search_messages` | Search messages — replaces `search_relative`/`search_absolute` for Graylog 6.x |
+| `aggregate_messages` | Group-by + metrics (top-N terms, histogram, any aggregation) — replaces `search_terms`/`search_histogram` for Graylog 6.x |
 
 ### Search (legacy — Graylog 4.x / 5.x only)
 
@@ -114,5 +114,5 @@ docker run -i --rm --network host \
 
 | Tool | Description |
 |---|---|
-| `system_overview` | Graylog system info (version, cluster, status) |
+| `get_system_status` | Graylog system info (version, cluster, hostname, timezone, status) |
 | `list_inputs` | List configured inputs |

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -114,5 +114,7 @@ docker run -i --rm --network host \
 
 | Tool | Description |
 |---|---|
+| `get_current_time` | Current UTC time — use to anchor relative time reasoning in skills |
 | `get_system_status` | Graylog system info (version, cluster, hostname, timezone, status) |
+| `list_fields` | Field names, types, and capabilities — scope to streams to reduce noise |
 | `list_inputs` | List configured inputs |

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -1,15 +1,17 @@
 # graylog-mcp
 
-MCP server for the Graylog REST API — log search, alerts, streams, and system info.
+MCP server for the Graylog REST API — log search, aggregations, alerts, pipelines, dashboards, and system info.
 
-> **Note:** Graylog 6.1+ ships a [built-in MCP server](https://github.com/Graylog2/graylog2-server). This server targets older Graylog versions (4.x / 5.x) that lack native MCP support.
+> **Note:** Graylog 6.1+ ships a [built-in MCP server](https://github.com/Graylog2/graylog2-server). This server targets Graylog 4.x / 5.x, but also works with 6.x where the built-in MCP is not available or preferred.
 
 ## Environment Variables
 
-| Variable | Required | Description |
-|---|---|---|
-| `GRAYLOG_URL` | yes | Graylog base URL (e.g. `http://localhost:9000`) |
-| `GRAYLOG_API_TOKEN` | yes | API token (create in System → Users → Tokens) |
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GRAYLOG_URL` | yes | — | Graylog base URL (e.g. `http://localhost:9000`) |
+| `GRAYLOG_API_TOKEN` | yes | — | API token (create in System → Users → Tokens) |
+| `GRAYLOG_VERIFY_SSL` | no | `true` | Set to `false` only for self-signed certs on trusted internal networks |
+| `LOG_LEVEL` | no | `WARNING` | Python log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 
 ## Run
 
@@ -28,7 +30,9 @@ docker run -i --rm --network host \
   "mcpServers": {
     "graylog": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "--network", "host", "-e", "GRAYLOG_URL", "-e", "GRAYLOG_API_TOKEN", "ghcr.io/gabrielbelli/graylog-mcp"],
+      "args": ["run", "-i", "--rm", "--network", "host",
+               "-e", "GRAYLOG_URL", "-e", "GRAYLOG_API_TOKEN",
+               "ghcr.io/gabrielbelli/graylog-mcp"],
       "env": {
         "GRAYLOG_URL": "http://localhost:9000",
         "GRAYLOG_API_TOKEN": ""
@@ -40,15 +44,75 @@ docker run -i --rm --network host \
 
 ## Tools
 
+### Search (Graylog 6.x — `views/search/sync`)
+
+> Use these tools on Graylog 6.x. The legacy search tools below return 0 results on 6.x.
+
 | Tool | Description |
 |---|---|
-| `search_relative` | Search messages with relative time range |
-| `search_absolute` | Search messages with absolute time range |
-| `search_keyword` | Search messages with natural language time range |
-| `get_message` | Retrieve a specific message by ID |
+| `search_sync` | Search messages — replaces `search_relative`/`search_absolute` for Graylog 6.x |
+| `aggregate_terms` | Top-N field value counts via pivot — replaces `search_terms` for Graylog 6.x |
+| `aggregate_histogram` | Message count over time via pivot — replaces `search_histogram` for Graylog 6.x |
+
+### Search (legacy — Graylog 4.x / 5.x only)
+
+| Tool | Description |
+|---|---|
+| `search_relative` | Search messages with relative time range (Lucene syntax) |
+| `search_absolute` | Search messages with absolute time range (ISO 8601) |
+| `search_keyword` | Search messages with natural language time range (e.g. "last 1 hour") |
+| `get_message` | Retrieve a specific message by ID and index |
+
+### Aggregations (legacy — Graylog 4.x / 5.x only)
+
+| Tool | Description |
+|---|---|
+| `search_terms` | Top-N values for a field (e.g. top source IPs, usernames, error codes) |
+| `search_stats` | Statistical summary for a numeric field (min, max, mean, sum, stddev) |
+| `search_histogram` | Message count bucketed over time — spot volume spikes or drops |
+| `search_field_histogram` | Numeric field value distribution over time |
+
+### Streams
+
+| Tool | Description |
+|---|---|
 | `list_streams` | List all streams |
 | `get_stream` | Get stream details |
-| `search_events` | Search alert events |
-| `list_event_definitions` | List alert/event definitions |
-| `system_overview` | Graylog system info |
+| `find_stream` | Find streams by name (case-insensitive substring match) |
+
+### Alerts & Events
+
+| Tool | Description |
+|---|---|
+| `search_events` | Search alert events with pagination |
+| `list_event_definitions` | List all alert/event definitions |
+
+### Pipelines
+
+> Requires the Graylog Processing Pipelines plugin (built-in since Graylog 4.x).
+
+| Tool | Description |
+|---|---|
+| `list_pipelines` | List all processing pipelines |
+| `get_pipeline` | Get pipeline details (stages, connected streams) |
+| `list_pipeline_rules` | List all pipeline rules |
+| `get_pipeline_rule` | Get rule source code and metadata |
+| `list_pipeline_connections` | Show which streams are connected to which pipelines |
+
+### Dashboards & Saved Searches
+
+> `list_saved_searches` and `get_saved_search` try the Graylog 5.x/6.x Views API first, and fall back to the 4.x saved search API automatically.
+
+| Tool | Description |
+|---|---|
+| `list_dashboards` | List all dashboards |
+| `get_dashboard` | Get a dashboard and its widget list |
+| `list_saved_searches` | List saved searches (version-agnostic) |
+| `get_saved_search` | Get a saved search by ID (version-agnostic) |
+
+### System
+
+| Tool | Description |
+|---|---|
+| `system_overview` | Graylog system info (version, cluster, status) |
 | `list_inputs` | List configured inputs |

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -72,20 +72,19 @@ docker run -i --rm --network host \
 | `search_histogram` | Message count bucketed over time — spot volume spikes or drops |
 | `search_field_histogram` | Numeric field value distribution over time |
 
-### Streams
+### Streams & Resources
 
 | Tool | Description |
 |---|---|
 | `list_streams` | List all streams |
-| `get_stream` | Get stream details |
-| `find_stream` | Find streams by name (case-insensitive substring match) |
+| `list_resource` | List streams, dashboards, or event definitions by type — returns GRNs |
+| `describe_resource` | Describe a specific resource by GRN (e.g. `grn::::stream:abc123`) |
 
 ### Alerts & Events
 
 | Tool | Description |
 |---|---|
 | `search_events` | Search alert events with pagination |
-| `list_event_definitions` | List all alert/event definitions |
 
 ### Pipelines
 
@@ -98,17 +97,6 @@ docker run -i --rm --network host \
 | `list_pipeline_rules` | List all pipeline rules |
 | `get_pipeline_rule` | Get rule source code and metadata |
 | `list_pipeline_connections` | Show which streams are connected to which pipelines |
-
-### Dashboards & Saved Searches
-
-> `list_saved_searches` and `get_saved_search` try the Graylog 5.x/6.x Views API first, and fall back to the 4.x saved search API automatically.
-
-| Tool | Description |
-|---|---|
-| `list_dashboards` | List all dashboards |
-| `get_dashboard` | Get a dashboard and its widget list |
-| `list_saved_searches` | List saved searches (version-agnostic) |
-| `get_saved_search` | Get a saved search by ID (version-agnostic) |
 
 ### System
 

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -12,6 +12,7 @@ MCP server for the Graylog REST API — log search, aggregations, alerts, pipeli
 | `GRAYLOG_API_TOKEN` | yes | — | API token (create in System → Users → Tokens) |
 | `GRAYLOG_VERIFY_SSL` | no | `true` | Set to `false` only for self-signed certs on trusted internal networks |
 | `LOG_LEVEL` | no | `WARNING` | Python log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `DOTENV_PATH` | no | `../../.env` relative to `server.py` | Override the `.env` file path for local development |
 
 ## Run
 

--- a/graylog-mcp/requirements.txt
+++ b/graylog-mcp/requirements.txt
@@ -1,2 +1,4 @@
 mcp[cli]>=1.0.0
 httpx>=0.27.0
+tenacity>=8.0.0
+python-dotenv>=1.0.0

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -733,10 +733,50 @@ def get_saved_search(search_id: str) -> dict:
 
 
 @mcp.tool()
+def get_current_time() -> dict:
+    """Get the current UTC time from the server.
+
+    Use this to anchor relative time reasoning. Without it, models tend to
+    infer current time from system start time and produce wrong durations.
+    """
+    from datetime import datetime, timezone
+    return {"current_time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")}
+
+
+@mcp.tool()
 def get_system_status() -> dict:
     """Get Graylog system information (version, cluster ID, hostname, timezone, status)."""
     try:
         return _get("/system")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def list_fields(streams: list[str] | None = None) -> dict:
+    """List available field names, types, and capabilities.
+
+    Field names differ per stream and over time. Use this before building
+    queries to discover which fields exist and what their types are.
+    Fields marked enumerable can be grouped in aggregate_messages.
+    Fields marked numeric support metric functions (avg, min, max, sum, etc).
+
+    Tries the Graylog 6.x /views/fields API first; falls back to /system/fields
+    for Graylog 4.x/5.x (which returns names only, without type metadata).
+
+    Args:
+        streams: Stream IDs to scope the field listing (empty = all accessible streams)
+    """
+    params: dict = {}
+    if streams:
+        params["streams[]"] = streams
+    try:
+        try:
+            return _get("/views/fields", params or None)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return _get("/system/fields")
+            raise
     except Exception as e:
         return _err(e)
 

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -4,29 +4,79 @@ Wraps the Graylog REST API and exposes search, streams, and alert endpoints
 as MCP tools for SOC workflows.
 """
 
+import logging
 import os
+from pathlib import Path
 
 import httpx
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
+logger = logging.getLogger("graylog-mcp")
 
 mcp = FastMCP("graylog")
 
 GRAYLOG_URL = os.environ.get("GRAYLOG_URL", "http://localhost:9000")
 GRAYLOG_API_TOKEN = os.environ.get("GRAYLOG_API_TOKEN", "")
+GRAYLOG_VERIFY_SSL = os.getenv("GRAYLOG_VERIFY_SSL", "true").lower() != "false"
+
+_http: httpx.Client | None = None
 
 
 def _client() -> httpx.Client:
-    return httpx.Client(
-        base_url=f"{GRAYLOG_URL}/api",
-        auth=(GRAYLOG_API_TOKEN, "token"),
-        headers={
-            "Accept": "application/json",
-            "X-Requested-By": "graylog-mcp",
-            "User-Agent": "graylog-mcp/1.0",
-        },
-        verify=False,
-        timeout=30,
-    )
+    global _http
+    if _http is None:
+        _http = httpx.Client(
+            base_url=f"{GRAYLOG_URL}/api",
+            auth=(GRAYLOG_API_TOKEN, "token"),
+            headers={
+                "Accept": "application/json",
+                "X-Requested-By": "graylog-mcp",
+                "User-Agent": "graylog-mcp/1.0",
+            },
+            verify=GRAYLOG_VERIFY_SSL,
+            timeout=30,
+        )
+    return _http
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _get(path: str, params: dict | None = None) -> dict:
+    logger.debug("GET %s params=%s", path, params)
+    r = _client().get(path, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _post(path: str, body: dict, params: dict | None = None) -> dict:
+    logger.debug("POST %s", path)
+    r = _client().post(path, json=body, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+def _err(e: Exception) -> dict:
+    if isinstance(e, httpx.HTTPStatusError):
+        return {
+            "error": f"HTTP {e.response.status_code}",
+            "url": str(e.request.url),
+            "detail": e.response.text[:500],
+        }
+    return {"error": type(e).__name__, "detail": str(e)}
 
 
 # ── Search ─────────────────────────────────────────────────────────────────
@@ -49,15 +99,15 @@ def search_relative(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "range": range_seconds, "limit": limit}
+    params: dict = {"query": query, "range": range_seconds, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/relative", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/relative", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -79,15 +129,15 @@ def search_absolute(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "from": from_time, "to": to_time, "limit": limit}
+    params: dict = {"query": query, "from": from_time, "to": to_time, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/absolute", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/absolute", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -107,15 +157,15 @@ def search_keyword(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "keyword": keyword, "limit": limit}
+    params: dict = {"query": query, "keyword": keyword, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/keyword", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/keyword", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -126,10 +176,10 @@ def get_message(message_id: str, index: str) -> dict:
         message_id: The message ID
         index: The Elasticsearch index containing the message
     """
-    with _client() as c:
-        r = c.get(f"/messages/{index}/{message_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/messages/{index}/{message_id}")
+    except Exception as e:
+        return _err(e)
 
 
 # ── Streams ────────────────────────────────────────────────────────────────
@@ -138,10 +188,10 @@ def get_message(message_id: str, index: str) -> dict:
 @mcp.tool()
 def list_streams() -> dict:
     """List all streams configured in Graylog."""
-    with _client() as c:
-        r = c.get("/streams")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/streams")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -151,10 +201,10 @@ def get_stream(stream_id: str) -> dict:
     Args:
         stream_id: The stream ID
     """
-    with _client() as c:
-        r = c.get(f"/streams/{stream_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/streams/{stream_id}")
+    except Exception as e:
+        return _err(e)
 
 
 # ── Alerts / Events ───────────────────────────────────────────────────────
@@ -175,27 +225,27 @@ def search_events(
         page: Page number (default: 1)
         per_page: Results per page (default: 50)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/events/search",
-            json={
+            {
                 "query": query,
                 "timerange": {"type": "relative", "range": timerange_from},
                 "page": page,
                 "per_page": per_page,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
 def list_event_definitions() -> dict:
     """List all event/alert definitions configured in Graylog."""
-    with _client() as c:
-        r = c.get("/events/definitions")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/events/definitions")
+    except Exception as e:
+        return _err(e)
 
 
 # ── System ─────────────────────────────────────────────────────────────────
@@ -204,19 +254,19 @@ def list_event_definitions() -> dict:
 @mcp.tool()
 def system_overview() -> dict:
     """Get Graylog system overview (version, cluster, status)."""
-    with _client() as c:
-        r = c.get("/system")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/system")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
 def list_inputs() -> dict:
     """List all configured inputs in Graylog."""
-    with _client() as c:
-        r = c.get("/system/inputs")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/system/inputs")
+    except Exception as e:
+        return _err(e)
 
 
 if __name__ == "__main__":

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -93,10 +93,6 @@ def _build_filter(stream_ids: list[str]) -> dict | None:
     return {"type": "or", "filters": filters}
 
 
-def _parse_stream_ids(stream_ids: str) -> list[str]:
-    return [s.strip() for s in stream_ids.split(",") if s.strip()]
-
-
 def _sync_search(body: dict, timeout_ms: int) -> dict:
     return _post("/views/search/sync", body, params={"timeout": timeout_ms})
 
@@ -204,55 +200,58 @@ def get_message(message_id: str, index: str) -> dict:
         return _err(e)
 
 
-# ── Search (Graylog 6.x — views/search/sync) ──────────────────────────────
+# ── Search & Aggregation (Graylog 6.x — views/search/sync) ────────────────
 
 
 @mcp.tool()
-def search_sync(
+def search_messages(
     query: str,
+    streams: list[str] | None = None,
+    stream_categories: list[str] | None = None,
+    fields: list[str] | None = None,
+    limit: int = 50,
+    offset: int = 0,
     range_seconds: int = 86400,
     from_time: str = "",
     to_time: str = "",
-    limit: int = 50,
-    fields: str = "",
-    stream_ids: str = "",
     sort_field: str = "timestamp",
     sort_order: str = "DESC",
     timeout_ms: int = 15000,
 ) -> dict:
-    """Search Graylog 6.x messages using the views/search/sync API.
+    """Search Graylog 6.x messages.
 
     Use this instead of search_relative or search_absolute on Graylog 6.x.
     The legacy /search/universal/* endpoints return no results on Graylog 6.x.
 
+    Pass the timerange via range_seconds or from_time+to_time — never embed time
+    in the query string. List only the fields you need; without fields, only
+    source and timestamp are returned. Scope to specific streams for performance.
+
     Args:
         query: Lucene query string (e.g. 'srcip:"1.2.3.4"', 'alert_severity:1')
-        range_seconds: Relative time window in seconds (default 86400 = 24h).
-                       Ignored when from_time and to_time are both set.
+        streams: Stream IDs to scope the search (empty = all streams)
+        stream_categories: Illuminate stream categories — Graylog 6.x with Illuminate only
+        fields: Field names to return. Empty = source and timestamp only.
+        limit: Maximum messages to return (default 50)
+        offset: Pagination offset (default 0)
+        range_seconds: Relative lookback in seconds (default 86400 = 24h).
+                       Ignored when from_time and to_time are both provided.
         from_time: Absolute start time ISO 8601 (e.g. 2025-04-01T00:00:00.000Z).
-                   Provide together with to_time to use an absolute range.
         to_time: Absolute end time ISO 8601.
-        limit: Maximum number of messages to return (default 50)
-        fields: Comma-separated field names to include in each message.
-                Empty string returns all stored fields.
-        stream_ids: Comma-separated stream IDs to scope the search.
-                    Empty string searches across all streams.
         sort_field: Field to sort by (default: timestamp)
         sort_order: ASC or DESC (default: DESC)
         timeout_ms: Server-side query timeout in milliseconds (default 15000)
     """
     try:
-        sid_list = _parse_stream_ids(stream_ids)
-        fields_list = [f.strip() for f in fields.split(",") if f.strip()]
         search_type: dict = {
             "id": "msgs",
             "type": "messages",
             "limit": limit,
-            "offset": 0,
+            "offset": offset,
             "sort": [{"field": sort_field, "order": sort_order}],
         }
-        if fields_list:
-            search_type["fields"] = fields_list
+        if fields:
+            search_type["fields"] = fields
 
         query_obj: dict = {
             "id": str(uuid.uuid4()),
@@ -260,9 +259,9 @@ def search_sync(
             "timerange": _build_timerange(range_seconds, from_time, to_time),
             "search_types": [search_type],
         }
-        f = _build_filter(sid_list)
-        if f:
-            query_obj["filter"] = f
+        flt = _build_filter(streams or [])
+        if flt:
+            query_obj["filter"] = flt
 
         raw = _sync_search({"queries": [query_obj]}, timeout_ms)
         qid = query_obj["id"]
@@ -278,85 +277,47 @@ def search_sync(
 
 
 @mcp.tool()
-def aggregate_terms(
-    field: str,
+def aggregate_messages(
+    groupings: list[dict],
+    metrics: list[dict] | None = None,
     query: str = "*",
-    range_seconds: int = 86400,
+    streams: list[str] | None = None,
+    stream_categories: list[str] | None = None,
+    range_seconds: int = 3600,
     from_time: str = "",
     to_time: str = "",
-    size: int = 20,
-    stream_ids: str = "",
     timeout_ms: int = 15000,
 ) -> dict:
-    """Get top-N values for a field using the Graylog 6.x views/search/sync API.
+    """Aggregate and group Graylog 6.x messages by field values or time buckets.
 
-    Use this instead of search_terms on Graylog 6.x.
+    Use this instead of search_terms or search_histogram on Graylog 6.x.
 
-    Args:
-        field: Field name to aggregate (e.g. "dstip", "alert_signature", "srcuser")
-        query: Lucene filter query (default: all messages)
-        range_seconds: Relative time window in seconds (default 86400 = 24h)
-        from_time: Absolute start time ISO 8601. Pair with to_time for absolute range.
-        to_time: Absolute end time ISO 8601.
-        size: Number of top values to return (default 20)
-        stream_ids: Comma-separated stream IDs. Empty = all streams.
-        timeout_ms: Server-side timeout in milliseconds (default 15000)
-    """
-    try:
-        sid_list = _parse_stream_ids(stream_ids)
-        search_type = {
-            "id": "terms_0",
-            "type": "pivot",
-            "row_groups": [{"type": "values", "field": field, "limit": size}],
-            "column_groups": [],
-            "series": [{"type": "count", "id": "count", "field": None}],
-            "rollup": False,
-        }
-        query_obj: dict = {
-            "id": str(uuid.uuid4()),
-            "query": {"type": "elasticsearch", "query_string": query},
-            "timerange": _build_timerange(range_seconds, from_time, to_time),
-            "search_types": [search_type],
-        }
-        f = _build_filter(sid_list)
-        if f:
-            query_obj["filter"] = f
+    Each grouping is either a field-value bucket or a time bucket:
+      {"field": "source", "limit": 10}               — top-N values for a field
+      {"field": "timestamp", "granularity": "hour"}   — time histogram
 
-        raw = _sync_search({"queries": [query_obj]}, timeout_ms)
-        qid = query_obj["id"]
-        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("terms_0", {})
-        terms = [
-            {"value": row["key"][0], "count": row["values"][0].get("value", 0)}
-            for row in st.get("rows", [])
-            if row.get("key")
-        ]
-        return {"field": field, "terms": terms}
-    except Exception as e:
-        return _err(e)
+    granularity options: "auto", "minute", "hour", "day", "week", "month"
 
+    Each metric defines what to compute per bucket:
+      {"function": "count"}                    — message count (default)
+      {"function": "avg", "field": "bytes"}    — numeric field metric
 
-@mcp.tool()
-def aggregate_histogram(
-    query: str = "*",
-    range_seconds: int = 86400,
-    from_time: str = "",
-    to_time: str = "",
-    interval: str = "auto",
-    stream_ids: str = "",
-    timeout_ms: int = 15000,
-) -> dict:
-    """Get message count bucketed over time using the Graylog 6.x views/search/sync API.
+    metric functions: count, avg, min, max, sum, stddev, card, latest
 
-    Use this instead of search_histogram on Graylog 6.x.
+    Examples:
+      Top 10 sources:  groupings=[{"field":"source","limit":10}], metrics=[{"function":"count"}]
+      Hourly volume:   groupings=[{"field":"timestamp","granularity":"hour"}], metrics=[{"function":"count"}]
+      Avg bytes/dest:  groupings=[{"field":"dstip","limit":20}], metrics=[{"function":"avg","field":"bytes"}]
 
     Args:
+        groupings: Required. One or more grouping dicts.
+        metrics: Metric dicts. Defaults to [{"function": "count"}].
         query: Lucene filter query (default: all messages)
-        range_seconds: Relative time window in seconds (default 86400 = 24h)
+        streams: Stream IDs to scope the search (empty = all streams)
+        stream_categories: Illuminate stream categories — Graylog 6.x with Illuminate only
+        range_seconds: Relative time window in seconds (default 3600 = 1 hour)
         from_time: Absolute start time ISO 8601. Pair with to_time for absolute range.
         to_time: Absolute end time ISO 8601.
-        interval: Bucket size — "auto", "minute", "hour", "day", "week", "month".
-                  "auto" lets Graylog choose based on the time range.
-        stream_ids: Comma-separated stream IDs. Empty = all streams.
         timeout_ms: Server-side timeout in milliseconds (default 15000)
     """
     _UNIT_MAP = {
@@ -367,26 +328,45 @@ def aggregate_histogram(
         "month": "MONTHS", "months": "MONTHS",
     }
     try:
-        sid_list = _parse_stream_ids(stream_ids)
-        if interval == "auto":
-            row_group = {
-                "type": "time",
-                "field": "timestamp",
-                "interval": {"type": "auto", "scaling": 1.0},
-            }
-        else:
-            unit = _UNIT_MAP.get(interval.lower(), "HOURS")
-            row_group = {
-                "type": "time",
-                "field": "timestamp",
-                "interval": {"type": "timeunit", "value": 1, "unit": unit},
-            }
+        row_groups = []
+        for g in groupings:
+            field = g.get("field", "")
+            if field == "timestamp" or "granularity" in g:
+                gran = g.get("granularity", "auto")
+                if gran == "auto":
+                    row_groups.append({
+                        "type": "time",
+                        "field": "timestamp",
+                        "interval": {"type": "auto", "scaling": 1.0},
+                    })
+                else:
+                    unit = _UNIT_MAP.get(gran.lower(), "HOURS")
+                    row_groups.append({
+                        "type": "time",
+                        "field": "timestamp",
+                        "interval": {"type": "timeunit", "value": 1, "unit": unit},
+                    })
+            else:
+                row_groups.append({
+                    "type": "values",
+                    "field": field,
+                    "limit": g.get("limit", 10),
+                })
+
+        series = []
+        for i, m in enumerate(metrics or [{"function": "count"}]):
+            fn = m["function"].lower()
+            s: dict = {"type": fn, "id": f"{fn}_{i}"}
+            if "field" in m:
+                s["field"] = m["field"]
+            series.append(s)
+
         search_type = {
-            "id": "hist_0",
+            "id": "agg_0",
             "type": "pivot",
-            "row_groups": [row_group],
+            "row_groups": row_groups,
             "column_groups": [],
-            "series": [{"type": "count", "id": "count", "field": None}],
+            "series": series,
             "rollup": False,
         }
         query_obj: dict = {
@@ -395,19 +375,25 @@ def aggregate_histogram(
             "timerange": _build_timerange(range_seconds, from_time, to_time),
             "search_types": [search_type],
         }
-        f = _build_filter(sid_list)
-        if f:
-            query_obj["filter"] = f
+        flt = _build_filter(streams or [])
+        if flt:
+            query_obj["filter"] = flt
 
         raw = _sync_search({"queries": [query_obj]}, timeout_ms)
         qid = query_obj["id"]
-        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("hist_0", {})
-        buckets = [
-            {"timestamp": row["key"][0], "count": row["values"][0].get("value", 0)}
+        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("agg_0", {})
+        rows = [
+            {
+                "key": row.get("key", []),
+                "values": {
+                    v.get("id", f"v{i}"): v.get("value")
+                    for i, v in enumerate(row.get("values", []))
+                },
+            }
             for row in st.get("rows", [])
             if row.get("key")
         ]
-        return {"interval": interval, "buckets": buckets}
+        return {"groupings": [g.get("field") for g in groupings], "rows": rows}
     except Exception as e:
         return _err(e)
 
@@ -747,8 +733,8 @@ def get_saved_search(search_id: str) -> dict:
 
 
 @mcp.tool()
-def system_overview() -> dict:
-    """Get Graylog system overview (version, cluster, status)."""
+def get_system_status() -> dict:
+    """Get Graylog system information (version, cluster ID, hostname, timezone, status)."""
     try:
         return _get("/system")
     except Exception as e:

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -522,46 +522,89 @@ def list_streams() -> dict:
         return _err(e)
 
 
+# ── Resources (streams, dashboards, event definitions) ────────────────────
+
+
 @mcp.tool()
-def get_stream(stream_id: str) -> dict:
-    """Get details for a specific stream.
+def list_resource(resource_type: str) -> dict:
+    """List Graylog resources of a given type, returning GRNs and names.
+
+    The GRN (Graylog Resource Name) returned for each item can be passed to
+    describe_resource to fetch its full details.
 
     Args:
-        stream_id: The stream ID
+        resource_type: One of "stream", "dashboard", "event_definition"
     """
+    t = resource_type.lower().removesuffix("s").replace(" ", "_")
     try:
-        return _get(f"/streams/{stream_id}")
+        if t == "stream":
+            data = _get("/streams")
+            return {
+                "resources": [
+                    {
+                        "grn": f"grn::::stream:{s['id']}",
+                        "name": s.get("title", ""),
+                        "description": s.get("description", ""),
+                        "disabled": s.get("disabled", False),
+                    }
+                    for s in data.get("streams", [])
+                ]
+            }
+        elif t == "dashboard":
+            data = _get("/views", {"type": "DASHBOARD", "page": 1, "per_page": 100})
+            return {
+                "resources": [
+                    {
+                        "grn": f"grn::::dashboard:{v['id']}",
+                        "name": v.get("title", ""),
+                        "description": v.get("description", ""),
+                    }
+                    for v in data.get("views", [])
+                ]
+            }
+        elif t in ("event_definition", "eventdefinition", "eventdef"):
+            data = _get("/events/definitions", {"page": 1, "per_page": 100})
+            return {
+                "resources": [
+                    {
+                        "grn": f"grn::::event_definition:{e['id']}",
+                        "name": e.get("title", ""),
+                        "description": e.get("description", ""),
+                    }
+                    for e in data.get("event_definitions", [])
+                ]
+            }
+        else:
+            return {"error": f"Unknown resource_type '{resource_type}'. Use: stream, dashboard, event_definition"}
     except Exception as e:
         return _err(e)
 
 
 @mcp.tool()
-def find_stream(name: str) -> dict:
-    """Find streams whose title matches a name (case-insensitive substring match).
+def describe_resource(grn: str) -> dict:
+    """Describe a specific Graylog resource by its GRN.
 
-    Call this at the start of an investigation to resolve a human-readable stream
-    name (e.g. "firewall", "proxy", "edr", "windows") into its Graylog stream ID.
-    Pass the returned id as stream_id to any search tool to scope queries to that
-    stream only instead of searching across all streams.
+    The GRN is the identifier returned by list_resource.
+    Format: grn::::TYPE:ID  e.g. grn::::stream:abc123
 
     Args:
-        name: Partial or full stream title to search for (e.g. "firewall", "proxy", "edr")
+        grn: Graylog Resource Name (e.g. grn::::stream:abc123)
     """
+    parts = grn.split(":")
+    # GRN format: "grn::::TYPE:ID" → ["grn", "", "", "", "TYPE", "ID"]
+    if len(parts) < 6 or parts[0] != "grn":
+        return {"error": f"Invalid GRN format: {grn!r}. Expected: grn::::TYPE:ID"}
+    grn_type = parts[4]
+    entity_id = ":".join(parts[5:])
     try:
-        result = _get("/streams")
-        streams = result.get("streams", [])
-        name_lower = name.lower()
-        matches = [
-            {
-                "id": s.get("id"),
-                "title": s.get("title"),
-                "description": s.get("description", ""),
-                "disabled": s.get("disabled", False),
-            }
-            for s in streams
-            if name_lower in s.get("title", "").lower()
-        ]
-        return {"query": name, "matches": matches, "total": len(matches)}
+        if grn_type == "stream":
+            return _get(f"/streams/{entity_id}")
+        elif grn_type == "dashboard":
+            return _get(f"/views/{entity_id}")
+        elif grn_type in ("event_definition", "eventdef"):
+            return _get(f"/events/definitions/{entity_id}")
+        else:
+            return {"error": f"Unsupported GRN type: {grn_type!r}"}
     except Exception as e:
         return _err(e)
 
@@ -594,15 +637,6 @@ def search_events(
                 "per_page": per_page,
             },
         )
-    except Exception as e:
-        return _err(e)
-
-
-@mcp.tool()
-def list_event_definitions() -> dict:
-    """List all event/alert definitions configured in Graylog."""
-    try:
-        return _get("/events/definitions")
     except Exception as e:
         return _err(e)
 
@@ -662,71 +696,6 @@ def list_pipeline_connections() -> dict:
     except Exception as e:
         return _err(e)
 
-
-# ── Dashboards & Saved Searches ────────────────────────────────────────────
-
-
-@mcp.tool()
-def list_dashboards() -> dict:
-    """List all dashboards in Graylog."""
-    try:
-        return _get("/dashboards")
-    except Exception as e:
-        return _err(e)
-
-
-@mcp.tool()
-def get_dashboard(dashboard_id: str) -> dict:
-    """Get a specific dashboard with its widget list.
-
-    Args:
-        dashboard_id: The dashboard ID
-    """
-    try:
-        return _get(f"/dashboards/{dashboard_id}")
-    except Exception as e:
-        return _err(e)
-
-
-@mcp.tool()
-def list_saved_searches() -> dict:
-    """List all saved searches.
-
-    Tries the Graylog 5.x/6.x Views API first, falls back to the 4.x saved search API.
-    """
-    try:
-        return _get("/search/views", {"type": "SEARCH"})
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            try:
-                return _get("/search/saved")
-            except Exception as e2:
-                return _err(e2)
-        return _err(e)
-    except Exception as e:
-        return _err(e)
-
-
-@mcp.tool()
-def get_saved_search(search_id: str) -> dict:
-    """Get a specific saved search by ID.
-
-    Tries the Graylog 5.x/6.x Views API first, falls back to the 4.x saved search API.
-
-    Args:
-        search_id: The saved search or view ID
-    """
-    try:
-        return _get(f"/search/views/{search_id}")
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            try:
-                return _get(f"/search/saved/{search_id}")
-            except Exception as e2:
-                return _err(e2)
-        return _err(e)
-    except Exception as e:
-        return _err(e)
 
 
 # ── System ─────────────────────────────────────────────────────────────────

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(os.getenv("DOTENV_PATH") or Path(__file__).parent.parent / ".env")
 logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
 logger = logging.getLogger("graylog-mcp")
 
@@ -44,10 +44,17 @@ def _client() -> httpx.Client:
     return _http
 
 
+def _reconnect(_retry_state) -> None:
+    """Drop the singleton client before each retry so a fresh connection is made."""
+    global _http
+    _http = None
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     retry=retry_if_exception_type(httpx.TransportError),
+    before_sleep=_reconnect,
     reraise=True,
 )
 def _get(path: str, params: dict | None = None) -> dict:
@@ -61,9 +68,10 @@ def _get(path: str, params: dict | None = None) -> dict:
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     retry=retry_if_exception_type(httpx.TransportError),
+    before_sleep=_reconnect,
     reraise=True,
 )
-def _post(path: str, body: dict, params: dict | None = None) -> dict:
+def _post(path: str, *, body: dict, params: dict | None = None) -> dict:
     logger.debug("POST %s", path)
     r = _client().post(path, json=body, params=params)
     r.raise_for_status()
@@ -94,7 +102,7 @@ def _build_filter(stream_ids: list[str]) -> dict | None:
 
 
 def _sync_search(body: dict, timeout_ms: int) -> dict:
-    return _post("/views/search/sync", body, params={"timeout": timeout_ms})
+    return _post("/views/search/sync", body=body, params={"timeout": timeout_ms})
 
 
 # ── Search (legacy — Graylog 4.x / 5.x) ──────────────────────────────────
@@ -630,7 +638,7 @@ def search_events(
     try:
         return _post(
             "/events/search",
-            {
+            body={
                 "query": query,
                 "timerange": {"type": "relative", "range": timerange_from},
                 "page": page,

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -1,11 +1,12 @@
 """Graylog MCP Server.
 
-Wraps the Graylog REST API and exposes search, streams, and alert endpoints
-as MCP tools for SOC workflows.
+Wraps the Graylog REST API and exposes search, streams, alerts, aggregations,
+pipelines, and dashboards as MCP tools for SOC workflows.
 """
 
 import logging
 import os
+import uuid
 from pathlib import Path
 
 import httpx
@@ -79,7 +80,28 @@ def _err(e: Exception) -> dict:
     return {"error": type(e).__name__, "detail": str(e)}
 
 
-# ── Search ─────────────────────────────────────────────────────────────────
+def _build_timerange(range_seconds: int | None, from_time: str, to_time: str) -> dict:
+    if from_time and to_time:
+        return {"type": "absolute", "from": from_time, "to": to_time}
+    return {"type": "relative", "range": range_seconds or 86400}
+
+
+def _build_filter(stream_ids: list[str]) -> dict | None:
+    filters = [{"type": "stream", "id": sid} for sid in stream_ids if sid]
+    if not filters:
+        return None
+    return {"type": "or", "filters": filters}
+
+
+def _parse_stream_ids(stream_ids: str) -> list[str]:
+    return [s.strip() for s in stream_ids.split(",") if s.strip()]
+
+
+def _sync_search(body: dict, timeout_ms: int) -> dict:
+    return _post("/views/search/sync", body, params={"timeout": timeout_ms})
+
+
+# ── Search (legacy — Graylog 4.x / 5.x) ──────────────────────────────────
 
 
 @mcp.tool()
@@ -182,6 +204,326 @@ def get_message(message_id: str, index: str) -> dict:
         return _err(e)
 
 
+# ── Search (Graylog 6.x — views/search/sync) ──────────────────────────────
+
+
+@mcp.tool()
+def search_sync(
+    query: str,
+    range_seconds: int = 86400,
+    from_time: str = "",
+    to_time: str = "",
+    limit: int = 50,
+    fields: str = "",
+    stream_ids: str = "",
+    sort_field: str = "timestamp",
+    sort_order: str = "DESC",
+    timeout_ms: int = 15000,
+) -> dict:
+    """Search Graylog 6.x messages using the views/search/sync API.
+
+    Use this instead of search_relative or search_absolute on Graylog 6.x.
+    The legacy /search/universal/* endpoints return no results on Graylog 6.x.
+
+    Args:
+        query: Lucene query string (e.g. 'srcip:"1.2.3.4"', 'alert_severity:1')
+        range_seconds: Relative time window in seconds (default 86400 = 24h).
+                       Ignored when from_time and to_time are both set.
+        from_time: Absolute start time ISO 8601 (e.g. 2025-04-01T00:00:00.000Z).
+                   Provide together with to_time to use an absolute range.
+        to_time: Absolute end time ISO 8601.
+        limit: Maximum number of messages to return (default 50)
+        fields: Comma-separated field names to include in each message.
+                Empty string returns all stored fields.
+        stream_ids: Comma-separated stream IDs to scope the search.
+                    Empty string searches across all streams.
+        sort_field: Field to sort by (default: timestamp)
+        sort_order: ASC or DESC (default: DESC)
+        timeout_ms: Server-side query timeout in milliseconds (default 15000)
+    """
+    try:
+        sid_list = _parse_stream_ids(stream_ids)
+        fields_list = [f.strip() for f in fields.split(",") if f.strip()]
+        search_type: dict = {
+            "id": "msgs",
+            "type": "messages",
+            "limit": limit,
+            "offset": 0,
+            "sort": [{"field": sort_field, "order": sort_order}],
+        }
+        if fields_list:
+            search_type["fields"] = fields_list
+
+        query_obj: dict = {
+            "id": str(uuid.uuid4()),
+            "query": {"type": "elasticsearch", "query_string": query},
+            "timerange": _build_timerange(range_seconds, from_time, to_time),
+            "search_types": [search_type],
+        }
+        f = _build_filter(sid_list)
+        if f:
+            query_obj["filter"] = f
+
+        raw = _sync_search({"queries": [query_obj]}, timeout_ms)
+        qid = query_obj["id"]
+        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("msgs", {})
+        messages = [m.get("message", m) for m in st.get("messages", [])]
+        return {
+            "total": st.get("total_results", 0),
+            "messages": messages,
+            "query": query,
+        }
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def aggregate_terms(
+    field: str,
+    query: str = "*",
+    range_seconds: int = 86400,
+    from_time: str = "",
+    to_time: str = "",
+    size: int = 20,
+    stream_ids: str = "",
+    timeout_ms: int = 15000,
+) -> dict:
+    """Get top-N values for a field using the Graylog 6.x views/search/sync API.
+
+    Use this instead of search_terms on Graylog 6.x.
+
+    Args:
+        field: Field name to aggregate (e.g. "dstip", "alert_signature", "srcuser")
+        query: Lucene filter query (default: all messages)
+        range_seconds: Relative time window in seconds (default 86400 = 24h)
+        from_time: Absolute start time ISO 8601. Pair with to_time for absolute range.
+        to_time: Absolute end time ISO 8601.
+        size: Number of top values to return (default 20)
+        stream_ids: Comma-separated stream IDs. Empty = all streams.
+        timeout_ms: Server-side timeout in milliseconds (default 15000)
+    """
+    try:
+        sid_list = _parse_stream_ids(stream_ids)
+        search_type = {
+            "id": "terms_0",
+            "type": "pivot",
+            "row_groups": [{"type": "values", "field": field, "limit": size}],
+            "column_groups": [],
+            "series": [{"type": "count", "id": "count", "field": None}],
+            "rollup": False,
+        }
+        query_obj: dict = {
+            "id": str(uuid.uuid4()),
+            "query": {"type": "elasticsearch", "query_string": query},
+            "timerange": _build_timerange(range_seconds, from_time, to_time),
+            "search_types": [search_type],
+        }
+        f = _build_filter(sid_list)
+        if f:
+            query_obj["filter"] = f
+
+        raw = _sync_search({"queries": [query_obj]}, timeout_ms)
+        qid = query_obj["id"]
+        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("terms_0", {})
+        terms = [
+            {"value": row["key"][0], "count": row["values"][0].get("value", 0)}
+            for row in st.get("rows", [])
+            if row.get("key")
+        ]
+        return {"field": field, "terms": terms}
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def aggregate_histogram(
+    query: str = "*",
+    range_seconds: int = 86400,
+    from_time: str = "",
+    to_time: str = "",
+    interval: str = "auto",
+    stream_ids: str = "",
+    timeout_ms: int = 15000,
+) -> dict:
+    """Get message count bucketed over time using the Graylog 6.x views/search/sync API.
+
+    Use this instead of search_histogram on Graylog 6.x.
+
+    Args:
+        query: Lucene filter query (default: all messages)
+        range_seconds: Relative time window in seconds (default 86400 = 24h)
+        from_time: Absolute start time ISO 8601. Pair with to_time for absolute range.
+        to_time: Absolute end time ISO 8601.
+        interval: Bucket size — "auto", "minute", "hour", "day", "week", "month".
+                  "auto" lets Graylog choose based on the time range.
+        stream_ids: Comma-separated stream IDs. Empty = all streams.
+        timeout_ms: Server-side timeout in milliseconds (default 15000)
+    """
+    _UNIT_MAP = {
+        "minute": "MINUTES", "minutes": "MINUTES",
+        "hour": "HOURS", "hours": "HOURS",
+        "day": "DAYS", "days": "DAYS",
+        "week": "WEEKS", "weeks": "WEEKS",
+        "month": "MONTHS", "months": "MONTHS",
+    }
+    try:
+        sid_list = _parse_stream_ids(stream_ids)
+        if interval == "auto":
+            row_group = {
+                "type": "time",
+                "field": "timestamp",
+                "interval": {"type": "auto", "scaling": 1.0},
+            }
+        else:
+            unit = _UNIT_MAP.get(interval.lower(), "HOURS")
+            row_group = {
+                "type": "time",
+                "field": "timestamp",
+                "interval": {"type": "timeunit", "value": 1, "unit": unit},
+            }
+        search_type = {
+            "id": "hist_0",
+            "type": "pivot",
+            "row_groups": [row_group],
+            "column_groups": [],
+            "series": [{"type": "count", "id": "count", "field": None}],
+            "rollup": False,
+        }
+        query_obj: dict = {
+            "id": str(uuid.uuid4()),
+            "query": {"type": "elasticsearch", "query_string": query},
+            "timerange": _build_timerange(range_seconds, from_time, to_time),
+            "search_types": [search_type],
+        }
+        f = _build_filter(sid_list)
+        if f:
+            query_obj["filter"] = f
+
+        raw = _sync_search({"queries": [query_obj]}, timeout_ms)
+        qid = query_obj["id"]
+        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("hist_0", {})
+        buckets = [
+            {"timestamp": row["key"][0], "count": row["values"][0].get("value", 0)}
+            for row in st.get("rows", [])
+            if row.get("key")
+        ]
+        return {"interval": interval, "buckets": buckets}
+    except Exception as e:
+        return _err(e)
+
+
+# ── Aggregations (legacy — Graylog 4.x / 5.x) ────────────────────────────
+
+
+@mcp.tool()
+def search_terms(
+    field: str,
+    query: str = "*",
+    range_seconds: int = 3600,
+    size: int = 10,
+    stream_id: str = "",
+) -> dict:
+    """Get top-N values for a field (term frequency / cardinality).
+
+    Useful for finding top source IPs, usernames, error codes, etc.
+
+    Args:
+        field: Field name to aggregate (e.g. "source", "gl2_source_input")
+        query: Filter query in Lucene syntax (default: all messages)
+        range_seconds: How far back to search in seconds (default: 3600 = 1 hour)
+        size: Number of top values to return (default: 10)
+        stream_id: Limit to a specific stream ID (optional)
+    """
+    params: dict = {"field": field, "query": query, "range": range_seconds, "size": size}
+    if stream_id:
+        params["filter"] = f"streams:{stream_id}"
+    try:
+        return _get("/search/universal/relative/terms", params)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def search_stats(
+    field: str,
+    query: str = "*",
+    range_seconds: int = 3600,
+    stream_id: str = "",
+) -> dict:
+    """Get statistical summary for a numeric field (min, max, mean, sum, stddev).
+
+    Args:
+        field: Numeric field name (e.g. "http_response_code", "took_ms")
+        query: Filter query in Lucene syntax (default: all messages)
+        range_seconds: How far back to search in seconds (default: 3600 = 1 hour)
+        stream_id: Limit to a specific stream ID (optional)
+    """
+    params: dict = {"field": field, "query": query, "range": range_seconds}
+    if stream_id:
+        params["filter"] = f"streams:{stream_id}"
+    try:
+        return _get("/search/universal/relative/stats", params)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def search_histogram(
+    query: str = "*",
+    range_seconds: int = 3600,
+    interval: str = "hour",
+    stream_id: str = "",
+) -> dict:
+    """Get message count over time (time-bucketed histogram).
+
+    Useful for spotting spikes or drops in log volume.
+
+    Args:
+        query: Filter query in Lucene syntax (default: all messages)
+        range_seconds: How far back to search in seconds (default: 3600 = 1 hour)
+        interval: Bucket size — minute, hour, day, week, month, quarter, year
+        stream_id: Limit to a specific stream ID (optional)
+    """
+    params: dict = {"query": query, "range": range_seconds, "interval": interval}
+    if stream_id:
+        params["filter"] = f"streams:{stream_id}"
+    try:
+        return _get("/search/universal/relative/histogram", params)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def search_field_histogram(
+    field: str,
+    query: str = "*",
+    range_seconds: int = 3600,
+    interval: str = "hour",
+    stream_id: str = "",
+) -> dict:
+    """Get a numeric field's value distribution over time.
+
+    Args:
+        field: Numeric field name (e.g. "took_ms", "bytes")
+        query: Filter query in Lucene syntax (default: all messages)
+        range_seconds: How far back to search in seconds (default: 3600 = 1 hour)
+        interval: Bucket size — minute, hour, day, week, month, quarter, year
+        stream_id: Limit to a specific stream ID (optional)
+    """
+    params: dict = {
+        "field": field,
+        "query": query,
+        "range": range_seconds,
+        "interval": interval,
+    }
+    if stream_id:
+        params["filter"] = f"streams:{stream_id}"
+    try:
+        return _get("/search/universal/relative/fieldhistogram", params)
+    except Exception as e:
+        return _err(e)
+
+
 # ── Streams ────────────────────────────────────────────────────────────────
 
 
@@ -203,6 +545,37 @@ def get_stream(stream_id: str) -> dict:
     """
     try:
         return _get(f"/streams/{stream_id}")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def find_stream(name: str) -> dict:
+    """Find streams whose title matches a name (case-insensitive substring match).
+
+    Call this at the start of an investigation to resolve a human-readable stream
+    name (e.g. "firewall", "proxy", "edr", "windows") into its Graylog stream ID.
+    Pass the returned id as stream_id to any search tool to scope queries to that
+    stream only instead of searching across all streams.
+
+    Args:
+        name: Partial or full stream title to search for (e.g. "firewall", "proxy", "edr")
+    """
+    try:
+        result = _get("/streams")
+        streams = result.get("streams", [])
+        name_lower = name.lower()
+        matches = [
+            {
+                "id": s.get("id"),
+                "title": s.get("title"),
+                "description": s.get("description", ""),
+                "disabled": s.get("disabled", False),
+            }
+            for s in streams
+            if name_lower in s.get("title", "").lower()
+        ]
+        return {"query": name, "matches": matches, "total": len(matches)}
     except Exception as e:
         return _err(e)
 
@@ -244,6 +617,128 @@ def list_event_definitions() -> dict:
     """List all event/alert definitions configured in Graylog."""
     try:
         return _get("/events/definitions")
+    except Exception as e:
+        return _err(e)
+
+
+# ── Pipelines ──────────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def list_pipelines() -> dict:
+    """List all processing pipelines configured in Graylog."""
+    try:
+        return _get("/system/pipelines/pipeline")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def get_pipeline(pipeline_id: str) -> dict:
+    """Get details for a specific processing pipeline, including its stages and rules.
+
+    Args:
+        pipeline_id: The pipeline ID
+    """
+    try:
+        return _get(f"/system/pipelines/pipeline/{pipeline_id}")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def list_pipeline_rules() -> dict:
+    """List all pipeline rules configured in Graylog."""
+    try:
+        return _get("/system/pipelines/rule")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def get_pipeline_rule(rule_id: str) -> dict:
+    """Get a specific pipeline rule, including its source code.
+
+    Args:
+        rule_id: The pipeline rule ID
+    """
+    try:
+        return _get(f"/system/pipelines/rule/{rule_id}")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def list_pipeline_connections() -> dict:
+    """List which streams are connected to which processing pipelines."""
+    try:
+        return _get("/system/pipelines/connections")
+    except Exception as e:
+        return _err(e)
+
+
+# ── Dashboards & Saved Searches ────────────────────────────────────────────
+
+
+@mcp.tool()
+def list_dashboards() -> dict:
+    """List all dashboards in Graylog."""
+    try:
+        return _get("/dashboards")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def get_dashboard(dashboard_id: str) -> dict:
+    """Get a specific dashboard with its widget list.
+
+    Args:
+        dashboard_id: The dashboard ID
+    """
+    try:
+        return _get(f"/dashboards/{dashboard_id}")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def list_saved_searches() -> dict:
+    """List all saved searches.
+
+    Tries the Graylog 5.x/6.x Views API first, falls back to the 4.x saved search API.
+    """
+    try:
+        return _get("/search/views", {"type": "SEARCH"})
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            try:
+                return _get("/search/saved")
+            except Exception as e2:
+                return _err(e2)
+        return _err(e)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def get_saved_search(search_id: str) -> dict:
+    """Get a specific saved search by ID.
+
+    Tries the Graylog 5.x/6.x Views API first, falls back to the 4.x saved search API.
+
+    Args:
+        search_id: The saved search or view ID
+    """
+    try:
+        return _get(f"/search/views/{search_id}")
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            try:
+                return _get(f"/search/saved/{search_id}")
+            except Exception as e2:
+                return _err(e2)
+        return _err(e)
     except Exception as e:
         return _err(e)
 

--- a/iris-mcp/requirements.txt
+++ b/iris-mcp/requirements.txt
@@ -1,2 +1,4 @@
 mcp[cli]>=1.0.0
 httpx>=0.27.0
+tenacity>=8.0.0
+python-dotenv>=1.0.0

--- a/iris-mcp/server.py
+++ b/iris-mcp/server.py
@@ -1,29 +1,99 @@
 """DFIR-IRIS MCP Server.
 
-Wraps the DFIR-IRIS REST API and exposes case management endpoints as MCP tools.
+Wraps the DFIR-IRIS REST API and exposes case management, IOC, asset, timeline,
+notes, and investigation tools as MCP tools for SOC workflows.
 """
 
+import logging
 import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import httpx
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
+logger = logging.getLogger("iris-mcp")
 
 mcp = FastMCP("dfir-iris")
 
 IRIS_URL = os.environ.get("IRIS_URL", "https://localhost:8443")
 IRIS_API_KEY = os.environ.get("IRIS_API_KEY", "")
+IRIS_VERIFY_SSL = os.getenv("IRIS_VERIFY_SSL", "false").lower() != "false"
+
+if not IRIS_API_KEY:
+    logger.warning("IRIS_API_KEY is not set — all API calls will fail with 401")
+
+_http: httpx.Client | None = None
 
 
 def _client() -> httpx.Client:
-    return httpx.Client(
-        base_url=IRIS_URL,
-        headers={
-            "Authorization": f"Bearer {IRIS_API_KEY}",
-            "User-Agent": "iris-mcp/1.0",
-        },
-        verify=False,
-        timeout=30,
-    )
+    global _http
+    if _http is None:
+        _http = httpx.Client(
+            base_url=IRIS_URL,
+            headers={
+                "Authorization": f"Bearer {IRIS_API_KEY}",
+                "User-Agent": "iris-mcp/1.0",
+                "Content-Type": "application/json",
+            },
+            verify=IRIS_VERIFY_SSL,
+            timeout=30,
+        )
+    return _http
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _get(path: str, params: dict | None = None) -> dict:
+    logger.debug("GET %s params=%s", path, params)
+    r = _client().get(path, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _post(path: str, params: dict | None = None, body: dict | None = None) -> dict:
+    logger.debug("POST %s", path)
+    r = _client().post(path, params=params, json=body or {})
+    r.raise_for_status()
+    return r.json()
+
+
+def _err(e: Exception) -> dict:
+    if isinstance(e, httpx.HTTPStatusError):
+        return {
+            "error": f"HTTP {e.response.status_code}",
+            "url": str(e.request.url),
+            "detail": e.response.text[:500],
+        }
+    return {"error": type(e).__name__, "detail": str(e)}
+
+
+def _parse_since(since: str) -> datetime | None:
+    """Parse a human time delta string into a UTC cutoff datetime."""
+    if not since:
+        return None
+    since = since.strip().lower()
+    units = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
+    if since[-1] in units and since[:-1].isdigit():
+        return datetime.now(timezone.utc) - timedelta(**{units[since[-1]]: int(since[:-1])})
+    try:
+        return datetime.fromisoformat(since).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
 
 
 # ── Cases ──────────────────────────────────────────────────────────────────
@@ -32,10 +102,10 @@ def _client() -> httpx.Client:
 @mcp.tool()
 def list_cases() -> dict:
     """List all cases in DFIR-IRIS."""
-    with _client() as c:
-        r = c.get("/manage/cases/list")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/manage/cases/list")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -45,10 +115,10 @@ def get_case(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get(f"/manage/cases/{case_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/manage/cases/{case_id}")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -66,18 +136,18 @@ def create_case(
         case_customer: Customer ID (default: 1)
         case_soc_id: SOC ticket ID (optional)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/manage/cases/add",
-            json={
+            body={
                 "case_name": case_name,
                 "case_description": case_description,
                 "case_customer": case_customer,
                 "case_soc_id": case_soc_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── IOCs ───────────────────────────────────────────────────────────────────
@@ -85,15 +155,15 @@ def create_case(
 
 @mcp.tool()
 def list_iocs(case_id: int) -> dict:
-    """List all IOCs (Indicators of Compromise) for a case.
+    """List all IOCs for a case.
 
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/ioc/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/ioc/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -107,25 +177,25 @@ def add_ioc(
     """Add an IOC to a case.
 
     Args:
-        case_id: The case ID to add the IOC to
+        case_id: The case ID
         ioc_value: The IOC value (IP, hash, domain, etc.)
-        ioc_type_id: Type of IOC (1=hash, 2=IP, 3=domain, etc.)
+        ioc_type_id: IOC type (1=hash, 2=IP, 3=domain, 4=URL, 5=email, 6=filename, 7=hostname)
         ioc_description: Description of the IOC
         ioc_tlp_id: TLP level (1=red, 2=amber, 3=green, 4=white)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/ioc/add",
             params={"cid": case_id},
-            json={
+            body={
                 "ioc_value": ioc_value,
                 "ioc_type_id": ioc_type_id,
                 "ioc_description": ioc_description,
                 "ioc_tlp_id": ioc_tlp_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Assets ─────────────────────────────────────────────────────────────────
@@ -138,10 +208,10 @@ def list_assets(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/assets/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/assets/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -157,23 +227,23 @@ def add_asset(
     Args:
         case_id: The case ID
         asset_name: Name or hostname of the asset
-        asset_type_id: Asset type (1=account, 2=firewall, 3=linux-server, 4=linux-workstation, 5=mac, 9=windows-server, 10=windows-workstation, etc.)
+        asset_type_id: Asset type (1=account, 2=firewall, 3=linux-server, 4=linux-workstation, 5=mac, 9=windows-server, 10=windows-workstation)
         asset_description: Description of the asset
         asset_compromise_status_id: Compromise status (0=unknown, 1=compromised, 2=not compromised, 3=remediated)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/assets/add",
             params={"cid": case_id},
-            json={
+            body={
                 "asset_name": asset_name,
                 "asset_type_id": asset_type_id,
                 "asset_description": asset_description,
                 "asset_compromise_status_id": asset_compromise_status_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Timeline ───────────────────────────────────────────────────────────────
@@ -186,10 +256,10 @@ def list_timeline(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/timeline/events/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/timeline/events/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -205,23 +275,23 @@ def add_timeline_event(
     Args:
         case_id: The case ID
         event_title: Title of the event
-        event_date: Date/time of the event (ISO format)
-        event_content: Detailed description
+        event_date: Date/time of the event (ISO 8601 format, e.g. 2024-01-15T10:00:00)
+        event_content: Detailed description (Markdown supported)
         event_category_id: Category ID for the event
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/timeline/events/add",
             params={"cid": case_id},
-            json={
+            body={
                 "event_title": event_title,
                 "event_date": event_date,
                 "event_content": event_content,
                 "event_category_id": event_category_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Notes ──────────────────────────────────────────────────────────────────
@@ -234,10 +304,10 @@ def list_notes_groups(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/notes/groups/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/notes/groups/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -255,18 +325,18 @@ def add_note(
         note_content: Markdown content of the note
         group_id: Note group ID to add the note to
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/notes/add",
             params={"cid": case_id},
-            json={
+            body={
                 "note_title": note_title,
                 "note_content": note_content,
                 "group_id": group_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 if __name__ == "__main__":

--- a/skills/graylog-hunt/README.md
+++ b/skills/graylog-hunt/README.md
@@ -1,0 +1,140 @@
+# graylog-hunt skill
+
+Autonomous SOC threat hunt for any indicator against a Graylog 6.x instance.
+
+The skill drives Claude through a structured five-phase investigation workflow — stream discovery, parallel log-type queries, SOC heuristics, an auto-pivot on the top lead, and a risk-tiered report with MITRE ATT&CK mapping — with no hardcoded client names or stream IDs.
+
+## Install
+
+```sh
+# From a local clone
+./install-skill graylog-hunt
+
+# Directly from GitHub
+curl -sL https://raw.githubusercontent.com/gabrielbelli/bluearmory/master/install-skill | sh -s graylog-hunt
+```
+
+## Usage
+
+### As a Claude Code skill
+
+Invoke with any indicator. Optionally append a time window.
+
+```
+/graylog-hunt 192.168.1.105
+/graylog-hunt 45.142.193.12 last 7 days
+/graylog-hunt jdoe last 24 hours
+/graylog-hunt evil.domain.com
+/graylog-hunt 4d5f3b9a1c2e...   # SHA256
+/graylog-hunt mimikatz last 3 days
+```
+
+Requires the `graylog` MCP server configured in your Claude Code environment (see [graylog-mcp](../../graylog-mcp/)).
+
+### Via the MCP `hunt` tool
+
+The `graylog-mcp` server exposes a `hunt` tool that runs this skill as an autonomous Claude sub-agent. Call it directly from any MCP client:
+
+```
+hunt("192.168.1.105")
+hunt("jdoe", range_seconds=604800)
+hunt("45.142.193.12 last 3 days")
+```
+
+The `hunt` tool requires `ANTHROPIC_API_KEY` in the server environment. See the [graylog-mcp README](../../graylog-mcp/README.md#with-the-hunt-tool-autonomous-investigation) for setup.
+
+## How it works
+
+### Phase 0 — Argument parsing & indicator classification
+
+Extracts an optional `last N unit` time window from the input (default: last 24 hours). Classifies the cleaned indicator:
+
+| Type | Pattern |
+|---|---|
+| `IPv4` | dotted-quad, no CIDR prefix |
+| `CIDR` | dotted-quad with `/prefix` — expands to Lucene range query |
+| `MD5 / SHA1 / SHA256` | 32 / 40 / 64 hex chars |
+| `Username` | contains `\`, or short alphanumeric ≤ 20 chars |
+| `Domain` | matches `hostname.tld`, no spaces |
+| `ProcessName` | ends in `.exe`, `.dll`, `.ps1`, `.bat`, `.vbs`, `.sh`, `.py`, `.elf` |
+| `FreeText` | anything else — quoted for Lucene |
+
+### Phase 1 — Dynamic stream discovery
+
+1. Calls `list_streams()` and filters out Graylog system streams (`All messages`, `All events`, `All system events`) and disabled streams.
+2. Probes every remaining stream **in parallel** with `aggregate_terms(field="program")` to discover what log sources each stream carries.
+3. Assigns roles based on top `program` values: `IDS` (suricata), `NGFW` (paloalto), `PROXY` (proxy), `WAF` (waf/nginx), `VPN` (openvpn/strongswan), `OTHER`.
+4. A stream can have multiple roles (e.g. suricata + nginx → IDS + WAF).
+5. Falls back to keyword matching in stream title/description if the program probe returns empty.
+
+No client names or stream IDs are hardcoded. The skill works on any Graylog instance.
+
+### Phase 2 — Parallel query execution
+
+All log-type blocks run simultaneously. Within each block, all field aggregations and message searches are also parallel.
+
+| Indicator type | IDS | NGFW | Proxy | WAF |
+|---|---|---|---|---|
+| IPv4 | alert sigs, MITRE, peer IPs, ports, histogram | actions, apps, threats, users | categories, risk, user-agents | rule IDs, blocked/detected |
+| CIDR | same as IPv4 + top active IPs within range | — | — | — |
+| Username | alert sigs, source IPs | source IPs, apps, rules, actions | URIs, risk, categories | — |
+| Domain | — | URL categories, source IPs | source IPs, risk, user-agents | rule IDs |
+| Hash | file events across IDS | — | — | — |
+| ProcessName / FreeText | broad sweep across all classified streams | — | — | — |
+
+Field families use automatic fallback: e.g. `srcip` → `src_ip` → `src` if earlier variants return no results.
+
+### Phase 3 — SOC heuristics (silent)
+
+Applied silently after Phase 2 to compute the risk tier. Key signals:
+
+- IDS severity 1 alerts with `alert_action=allowed` → Critical (active unblocked traffic)
+- MITRE C2 or lateral movement tactics → Critical
+- Histogram regularity (low variance across ≥ 6 buckets) → High (beaconing pattern)
+- NGFW `thr_category=code-execution` → Critical
+- Proxy `risk=High Risk` → High
+- WAF RCE rule IDs (932xx/933xx/934xx) → Critical; SQLi (942xx) / XSS (941xx) → High
+- C2/RAT common destination ports (4444, 1337, 6667, 4899, …) → High
+
+### Phase 4 — Auto-pivot (one level)
+
+Identifies the single highest-risk new lead from Phase 2/3 (C2 destination IP, threat-associated username, DGA domain, multi-source hash) and reruns the appropriate Phase 2 block for it. Does not recurse further.
+
+### Phase 5 — Report
+
+Structured Markdown report:
+
+```
+Indicator | Type | Period | Streams searched
+
+## Summary
+## IDS Findings       — sigs, MITRE table, peer IPs, sample events
+## NGFW Findings      — actions, apps, threat categories, rules, users
+## Proxy Findings     — URL categories, risk, user-agents, sample URLs
+## WAF Findings       — OWASP rule IDs, blocked vs detected, attacker IPs
+## Alert Events       — triggered Graylog alert definitions
+## Activity Timeline  — narrative: sustained / spike / periodic / beaconing
+## Auto-Pivot         — 3-sentence pivot finding (omitted if no pivot)
+## Assessment         — Risk Tier (T1–T5), MITRE mapping, recommended action
+```
+
+External IPs and FQDNs are defanged (`1[.]2[.]3[.]4`). RFC1918 addresses are not defanged.
+
+## Time window syntax
+
+Append to any indicator:
+
+```
+last 6 hours       → 21600 seconds
+last 24 hours      → 86400 seconds  (default)
+last 7 days
+last 2 weeks
+```
+
+When used via the `hunt` MCP tool, set `range_seconds` directly instead.
+
+## Requirements
+
+- Graylog MCP server configured and reachable (see [graylog-mcp](../../graylog-mcp/))
+- Graylog 6.x (uses `views/search/sync` API; legacy `search_relative` etc. return 0 results on 6.x)
+- For the `hunt` MCP tool: `ANTHROPIC_API_KEY` set in the server environment

--- a/skills/graylog-hunt/SKILL.md
+++ b/skills/graylog-hunt/SKILL.md
@@ -1,0 +1,558 @@
+---
+name: graylog-hunt
+description: >
+  SOC threat hunt for any indicator (IP, CIDR, username, domain, hostname, hash,
+  process name, or free text) against a Graylog 6.x instance. Discovers stream
+  roles dynamically by probing the program field, routes queries per log type,
+  applies SOC heuristics, auto-pivots on the highest-risk lead, and produces a
+  structured risk-tiered report with MITRE ATT&CK mapping.
+---
+
+Hunt for: $ARGUMENTS
+
+---
+
+## Argument parsing
+
+Extract optional time window suffix from `$ARGUMENTS`:
+- Pattern: `last <N> <unit>` — e.g. `last 7 days`, `last 6h`, `last 24 hours`
+- Units: `h`/`hour`/`hours` → N × 3600; `d`/`day`/`days` → N × 86400; `w`/`week`/`weeks` → N × 604800; bare integer → seconds
+- Default when no suffix: `last 24 hours` → `range_seconds = 86400`
+
+Store the cleaned indicator (with the time suffix removed) as `RAW_INDICATOR`.
+Store the computed seconds as `RANGE`.
+
+---
+
+## Phase 0 — Classify the indicator
+
+Classify `RAW_INDICATOR` before making any MCP calls.
+
+| Pattern | Type |
+|---|---|
+| `\d{1,3}(\.\d{1,3}){3}` with no `/` | `IPv4` |
+| `\d{1,3}(\.\d{1,3}){3}/\d{1,2}` | `CIDR` — expand to `[lo TO hi]` Lucene range |
+| Exactly 32 hex chars | `MD5` |
+| Exactly 40 hex chars | `SHA1` |
+| Exactly 64 hex chars | `SHA256` |
+| Contains `\` or matches `WORD\WORD` | `Username` — also keep domain prefix for exact search |
+| Ends in `.exe .dll .ps1 .bat .vbs .sh .py .elf` | `ProcessName` |
+| Matches `^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$` and no spaces | `Domain` |
+| Short alphanumeric (≤ 20 chars, no spaces, no special chars) | `Username` — ambiguous, also search as hostname |
+| Anything else | `FreeText` — wrap in double-quotes for Lucene |
+
+For `CIDR`: compute the network address and broadcast address from the prefix length, then build:
+`srcip:[<lo> TO <hi>] OR src_ip:[<lo> TO <hi>] OR src:[<lo> TO <hi>]`
+
+Print the classification result before proceeding.
+
+---
+
+## Phase 1 — Stream discovery and role mapping
+
+**Step 1.1** — Call `list_streams()` once.
+
+**Filter out** any stream where:
+- `title.lower() == "all messages"`, OR
+- `title.lower() == "all events"`, OR
+- `title.lower() == "all system events"`, OR
+- `disabled == true`
+
+These are Graylog system streams. Including them in scoped queries would duplicate results or expose cross-tenant data.
+
+**Step 1.2** — Probe each remaining stream in parallel. For every stream, call:
+
+```
+aggregate_messages(
+    groupings=[{"field": "program", "limit": 10}],
+    query="*",
+    range_seconds=RANGE,
+    streams=["<stream_id>"],
+    timeout_ms=8000
+)
+```
+
+Run all probes simultaneously in a single message (multiple tool calls).
+
+**Step 1.3** — Assign roles based on the top `program` values returned:
+
+| `program` value | Role |
+|---|---|
+| `suricata` | `IDS` |
+| `paloalto` | `NGFW` |
+| `proxy` | `PROXY` |
+| `waf` or `nginx` | `WAF` |
+| `openvpn*`, `ppp*`, `strongswan*` | `VPN` |
+| anything else with count > 0 | `OTHER` |
+
+A stream gets every role whose `program` value appears in its top-10 terms. A stream with both `suricata` and `nginx` is both `IDS` and `WAF`.
+
+If a stream probe returns empty terms (no `program` field, or no messages in the time window), fall back to keyword matching in the stream's `title` and `description`:
+- `suricata`, `ids`, `ips` → `IDS`
+- `paloalto`, `palo`, `ngfw`, `firewall`, `fw` → `NGFW`
+- `proxy`, `squid`, `zscaler`, `bluecoat` → `PROXY`
+- `waf`, `modsec`, `nginx` → `WAF`
+- `vpn`, `openvpn`, `ssl vpn` → `VPN`
+
+Build these stream ID lists (Python lists of ID strings):
+```
+IDS_IDS    = list of IDs of all IDS-role streams
+NGFW_IDS   = list of IDs of all NGFW-role streams
+PROXY_IDS  = list of IDs of all PROXY-role streams
+WAF_IDS    = list of IDs of all WAF-role streams
+ALL_IDS    = list of IDs of ALL classified streams (IDS + NGFW + PROXY + WAF + VPN + OTHER)
+```
+
+Print the mapping before Phase 2:
+```
+Stream roles resolved:
+  IDS:   <comma-separated stream titles>
+  NGFW:  <comma-separated stream titles>
+  PROXY: <comma-separated stream titles>
+  WAF:   <comma-separated stream titles>
+  VPN:   <comma-separated stream titles>
+  OTHER: <comma-separated stream titles>
+```
+
+If a role has no streams, skip all queries for that role. Do not fall back to unscoped searches.
+
+---
+
+## Phase 2 — Query execution
+
+### Field fallback rule
+
+If a query returns `total == 0` **and** `rows` (or `messages`) is empty, retry with the next field name variant. Maximum 2 retries per field family. If all variants return 0, record "no data" for that dimension and continue.
+
+Field fallback tables:
+
+| Family | Try in order |
+|---|---|
+| Source IP | `srcip`, `src_ip`, `src` |
+| Destination IP | `dstip`, `dst_ip`, `dst` |
+| Destination port | `dst_port`, `dport`, `dest_port` |
+| Source port | `src_port`, `sport` |
+| Username | `srcuser`, `username`, `user` |
+| Action | `action`, `alert_action` |
+| Alert signature | `alert_signature`, `alert_category` |
+
+### Parallelism rules
+
+1. All Phase 1 stream probes: fully parallel.
+2. All queries within a single log-type block (all IDS queries, all NGFW queries, etc.): fully parallel.
+3. All log-type blocks themselves: fully parallel — start IDS, NGFW, PROXY, and WAF blocks simultaneously.
+4. Field fallback retries: sequential within a retry chain.
+5. Alert events and IRIS calls: parallel with Phase 2 blocks.
+
+---
+
+### 2A — IPv4 investigation
+
+Build these query strings:
+```
+SRC_Q = 'srcip:"<ip>" OR src_ip:"<ip>" OR src:"<ip>"'
+DST_Q = 'dstip:"<ip>" OR dst_ip:"<ip>" OR dst:"<ip>"'
+ANY_Q = SRC_Q + " OR " + DST_Q
+```
+
+**IDS block** (skip if IDS_IDS is empty) — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"alert_signature","limit":20}],                     query=ANY_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"alert_category","limit":10}],                      query=ANY_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"alert_severity","limit":5}],                       query=ANY_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"alert_action","limit":5}],                         query=ANY_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"dstip","limit":20}],                               query=SRC_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"dst_port","limit":20}],                            query=SRC_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"app_proto","limit":10}],                           query=ANY_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"alert_metadata_mitre_tactic_name","limit":10}],    query=ANY_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"alert_metadata_mitre_technique_name","limit":10}], query=ANY_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"timestamp","granularity":"auto"}],                  query=ANY_Q, range_seconds=RANGE, streams=IDS_IDS)
+search_messages(query=ANY_Q, range_seconds=RANGE, limit=15,
+                fields=["timestamp","srcip","dstip","dst_port","alert_signature","alert_severity","alert_action","alert_category","app_proto","direction"],
+                streams=IDS_IDS)
+```
+
+**NGFW block** (skip if NGFW_IDS is empty) — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"action","limit":10}],       query=SRC_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"dstip","limit":20}],        query=SRC_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"dport","limit":20}],        query=SRC_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"app","limit":15}],          query=ANY_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"srcuser","limit":10}],      query=SRC_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"rule","limit":10}],         query=ANY_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"thr_category","limit":10}], query=ANY_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"subtype","limit":10}],      query=ANY_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"severity","limit":5}],      query=ANY_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"srcip","limit":20}],        query=DST_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"timestamp","granularity":"auto"}],  query=ANY_Q, range_seconds=RANGE, streams=NGFW_IDS)
+search_messages(query=ANY_Q, range_seconds=RANGE, limit=15,
+                fields=["timestamp","srcip","dstip","dport","sport","action","app","rule","srcuser","type","subtype","severity","thr_category","srcloc","dstloc","from","to"],
+                streams=NGFW_IDS)
+```
+
+**PROXY block** (skip if PROXY_IDS is empty) — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"type","limit":10}],     query=SRC_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"risk","limit":5}],      query=SRC_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"response","limit":10}], query=SRC_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"agent","limit":10}],    query=SRC_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"timestamp","granularity":"auto"}], query=SRC_Q, range_seconds=RANGE, streams=PROXY_IDS)
+search_messages(query=SRC_Q, range_seconds=RANGE, limit=15,
+                fields=["timestamp","srcip","uri","type","risk","response","agent","source_servico"],
+                streams=PROXY_IDS)
+```
+
+**WAF block** (skip if WAF_IDS is empty) — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"action","limit":5}],                    query=DST_Q, range_seconds=RANGE, streams=WAF_IDS)
+aggregate_messages(groupings=[{"field":"messages_details_ruleId","limit":20}],  query=DST_Q, range_seconds=RANGE, streams=WAF_IDS)
+aggregate_messages(groupings=[{"field":"messages_details_severity","limit":5}], query=DST_Q, range_seconds=RANGE, streams=WAF_IDS)
+aggregate_messages(groupings=[{"field":"http_user_agent","limit":10}],          query=DST_Q, range_seconds=RANGE, streams=WAF_IDS)
+aggregate_messages(groupings=[{"field":"http_x_forwarded_for","limit":10}],     query=DST_Q, range_seconds=RANGE, streams=WAF_IDS)
+search_messages(query=DST_Q, range_seconds=RANGE, limit=15,
+                fields=["timestamp","host","host_ip","action","messages_details_ruleId","messages_details_severity","messages_details_match","http_user_agent","http_x_forwarded_for","request"],
+                streams=WAF_IDS)
+```
+
+**Events** (no stream filter):
+```
+search_events(query="<ip>", timerange_from=RANGE)
+```
+
+---
+
+### 2B — CIDR investigation
+
+Compute `LO` and `HI` addresses from the prefix length. Build:
+```
+SRC_Q = 'srcip:[<LO> TO <HI>] OR src_ip:[<LO> TO <HI>] OR src:[<LO> TO <HI>]'
+DST_Q = 'dstip:[<LO> TO <HI>] OR dst_ip:[<LO> TO <HI>] OR dst:[<LO> TO <HI>]'
+ANY_Q = SRC_Q + " OR " + DST_Q
+```
+
+Run the same IDS, NGFW, PROXY, WAF blocks as 2A (substituting the range queries).
+
+Add these to identify the most active individual IPs within the range (run in parallel with 2A blocks):
+```
+aggregate_messages(groupings=[{"field":"srcip","limit":20}], query=SRC_Q, range_seconds=RANGE, streams=ALL_IDS)
+aggregate_messages(groupings=[{"field":"dstip","limit":20}], query=DST_Q, range_seconds=RANGE, streams=ALL_IDS)
+```
+
+---
+
+### 2C — Username investigation
+
+```
+USER_Q = 'srcuser:"<user>" OR username:"<user>" OR user:"<user>"'
+```
+If the original input had a domain prefix (`DOMAIN\user`), also append:
+`OR srcuser:"DOMAIN\\<user>"`
+
+**NGFW block** — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"srcip","limit":20}],  query=USER_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"dstip","limit":20}],  query=USER_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"dport","limit":20}],  query=USER_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"action","limit":10}], query=USER_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"app","limit":10}],    query=USER_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"rule","limit":10}],   query=USER_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"timestamp","granularity":"auto"}], query=USER_Q, range_seconds=RANGE, streams=NGFW_IDS)
+search_messages(query=USER_Q, range_seconds=RANGE, limit=20,
+                fields=["timestamp","srcip","dstip","dport","action","app","rule","srcuser","type","subtype","severity"],
+                streams=NGFW_IDS)
+```
+
+**IDS block** — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"alert_signature","limit":20}], query=USER_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"srcip","limit":20}],           query=USER_Q, range_seconds=RANGE, streams=IDS_IDS)
+search_messages(query=USER_Q, range_seconds=RANGE, limit=10,
+                fields=["timestamp","srcip","dstip","dst_port","alert_signature","alert_severity"],
+                streams=IDS_IDS)
+```
+
+**PROXY block** — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"uri","limit":20}],      query=USER_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"type","limit":10}],     query=USER_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"risk","limit":5}],      query=USER_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"response","limit":10}], query=USER_Q, range_seconds=RANGE, streams=PROXY_IDS)
+```
+
+**Events** (no filter):
+```
+search_events(query="<user>", timerange_from=RANGE)
+```
+
+---
+
+### 2D — Domain investigation
+
+```
+DOMAIN_Q = 'misc:"<domain>" OR uri:"<domain>" OR host:"<domain>" OR dst_domain:"<domain>"'
+```
+
+**PROXY block** — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"srcip","limit":20}],    query=DOMAIN_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"risk","limit":5}],      query=DOMAIN_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"response","limit":10}], query=DOMAIN_Q, range_seconds=RANGE, streams=PROXY_IDS)
+aggregate_messages(groupings=[{"field":"timestamp","granularity":"auto"}], query=DOMAIN_Q, range_seconds=RANGE, streams=PROXY_IDS)
+search_messages(query=DOMAIN_Q, range_seconds=RANGE, limit=20,
+                fields=["timestamp","srcip","uri","type","risk","response","agent"],
+                streams=PROXY_IDS)
+```
+
+**NGFW block** — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"srcip","limit":20}],             query=DOMAIN_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"action","limit":10}],            query=DOMAIN_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"url_category_list","limit":10}], query=DOMAIN_Q, range_seconds=RANGE, streams=NGFW_IDS)
+aggregate_messages(groupings=[{"field":"srcuser","limit":10}],           query=DOMAIN_Q, range_seconds=RANGE, streams=NGFW_IDS)
+search_messages(query=DOMAIN_Q, range_seconds=RANGE, limit=15,
+                fields=["timestamp","srcip","misc","action","url_category_list","type","srcuser","severity"],
+                streams=NGFW_IDS)
+```
+
+**WAF block** — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"http_x_forwarded_for","limit":10}],    query=DOMAIN_Q, range_seconds=RANGE, streams=WAF_IDS)
+aggregate_messages(groupings=[{"field":"messages_details_ruleId","limit":10}], query=DOMAIN_Q, range_seconds=RANGE, streams=WAF_IDS)
+search_messages(query=DOMAIN_Q, range_seconds=RANGE, limit=10,
+                fields=["timestamp","host","host_ip","action","messages_details_ruleId","http_user_agent"],
+                streams=WAF_IDS)
+```
+
+**Events**:
+```
+search_events(query="<domain>", timerange_from=RANGE)
+```
+
+---
+
+### 2E — Hash investigation (MD5 / SHA1 / SHA256)
+
+```
+HASH_Q = '"<hash>"'
+```
+
+**IDS block** (suricata logs file metadata with hashes) — all in parallel:
+```
+aggregate_messages(groupings=[{"field":"srcip","limit":20}], query=HASH_Q, range_seconds=RANGE, streams=IDS_IDS)
+aggregate_messages(groupings=[{"field":"dstip","limit":20}], query=HASH_Q, range_seconds=RANGE, streams=IDS_IDS)
+search_messages(query=HASH_Q, range_seconds=RANGE, limit=20,
+                fields=["timestamp","srcip","dstip","dst_port","files","event_type","app_proto"],
+                streams=IDS_IDS)
+```
+
+**Broad sweep across all classified streams**:
+```
+search_messages(query=HASH_Q, range_seconds=RANGE, limit=30, streams=ALL_IDS)
+search_events(query="<hash>", timerange_from=RANGE)
+```
+
+---
+
+### 2F — ProcessName investigation
+
+```
+PROC_Q = '"<name>"'
+```
+
+```
+search_messages(query=PROC_Q, range_seconds=RANGE, limit=50, streams=ALL_IDS)
+aggregate_messages(groupings=[{"field":"srcip","limit":20}],           query=PROC_Q, range_seconds=RANGE, streams=ALL_IDS)
+aggregate_messages(groupings=[{"field":"alert_signature","limit":10}], query=PROC_Q, range_seconds=RANGE, streams=IDS_IDS)
+search_events(query="<name>", timerange_from=RANGE)
+```
+
+---
+
+### 2G — FreeText investigation
+
+```
+FREE_Q = '"<RAW_INDICATOR>"'
+```
+
+No stream scoping — uses ALL_IDS:
+```
+search_messages(query=FREE_Q, range_seconds=RANGE, limit=50, streams=ALL_IDS)
+aggregate_messages(groupings=[{"field":"program","limit":10}], query=FREE_Q, range_seconds=RANGE, streams=ALL_IDS)
+aggregate_messages(groupings=[{"field":"srcip","limit":20}],   query=FREE_Q, range_seconds=RANGE, streams=ALL_IDS)
+aggregate_messages(groupings=[{"field":"dstip","limit":20}],   query=FREE_Q, range_seconds=RANGE, streams=ALL_IDS)
+aggregate_messages(groupings=[{"field":"timestamp","granularity":"auto"}], query=FREE_Q, range_seconds=RANGE, streams=ALL_IDS)
+search_events(query="<RAW_INDICATOR>", timerange_from=RANGE)
+```
+
+---
+
+## Phase 3 — SOC heuristics (silent)
+
+Apply after Phase 2. Do not output intermediate results. Use findings only to drive Phase 4 and the risk tier in Phase 5.
+
+### IP / CIDR
+
+| Signal | Risk contribution |
+|---|---|
+| IDS `alert_severity` term `1` count > 0 | Critical |
+| IDS `alert_severity` term `2` count > 0 | High |
+| IDS has alerts but `alert_action` = `allowed` only (no `blocked`) | High — active unblocked traffic |
+| IDS MITRE tactic contains `Command_And_Control` | Critical |
+| IDS MITRE tactic contains `Lateral_Movement` or `Exfiltration` | Critical |
+| Histogram bucket counts nearly equal (variance < 20 % of mean) and N ≥ 6 buckets | High — beaconing pattern |
+| NGFW `thr_category` contains `code-execution` | Critical |
+| NGFW `thr_category` contains `dos` or `brute-force` | High |
+| NGFW `action` = `drop`/`drop-packet`/`reset-*` with count > 500 | Medium — blocked but persistent |
+| NGFW `action` = `alert` with `type=THREAT` and no drop action | High — NGFW alerting but not blocking |
+| Proxy `risk` = `High Risk` terms present | High |
+| Proxy `risk` = `Medium Risk` and `response=200` | Medium — successful access |
+| WAF `action` = `detected` only (no `blocked`) | Medium — WAF not in blocking mode |
+| WAF `messages_details_ruleId` starts with `932`, `933`, `934` (RCE) | Critical |
+| WAF `messages_details_ruleId` starts with `942` (SQLi) | High |
+| WAF `messages_details_ruleId` starts with `941` (XSS) | High |
+| IP appears in `*_reserved_ip=true` fields | Context only (internal IP) |
+| `dport` / `dst_port` includes 3333, 4444, 5555, 1337, 14444, 6667, 4899 | High — common C2/RAT ports |
+| `dport` 22 with > 10 unique `dstip` values | High — SSH scanning |
+| NGFW `type=URL` hits only, `srcuser` present | Low — routine user browsing |
+
+### Username
+
+| Signal | Risk contribution |
+|---|---|
+| Same username associated with > 3 unique source IPs in NGFW | High — credential sharing or lateral movement |
+| Username associated with `type=THREAT` in NGFW | High |
+| Username browses `High Risk` proxy categories | Medium |
+
+### Domain
+
+| Signal | Risk contribution |
+|---|---|
+| Proxy `risk` = `High Risk` | High |
+| > 10 unique source IPs accessing domain | High — potential malware callback |
+| WAF `action=blocked` from this domain as origin | Medium |
+| NGFW `url_category_list` contains `malware`, `phishing`, or `botnet` | Critical |
+| Domain name matches DGA pattern (10+ consecutive random-looking chars before first dot, or unusual TLD like `.xyz`, `.top`, `.tk`, `.pw`) | High |
+
+---
+
+## Phase 4 — Auto-pivot (maximum 1 level)
+
+Identify the single most suspicious new lead found in Phase 2/3. Priority order:
+
+1. If MITRE tactic is Critical and a specific `dstip` (not the indicator itself) is the top IDS term → pivot to that IP.
+2. If a username was found as a top `srcuser` term associated with `type=THREAT` events → pivot to that username.
+3. If a `misc` or `uri` domain from NGFW/Proxy is DGA-like or has an unusual TLD → pivot to that domain.
+4. If a hash appears in IDS file events across multiple source IPs → pivot to the most active source IP.
+
+Pivot: run the appropriate Phase 2 block(s) for the pivot indicator type, with the same `RANGE` and same stream IDs. Summarise findings in 3 sentences. List remaining leads as "further investigation recommended."
+
+Do not pivot again from the pivot result.
+
+---
+
+## Phase 5 — Write the report
+
+**Defanging rule:** replace every `.` in external (non-RFC1918) IPs and FQDNs with `[.]`. Do not defang RFC1918 addresses (`10.x`, `172.16–31.x`, `192.168.x`).
+
+---
+
+```
+**Indicator:** `<RAW_INDICATOR>` | **Type:** <type> | **Period:** last <N> h/d
+**Streams searched:** IDS=<titles or "none">, NGFW=<titles or "none">, PROXY=<titles or "none">, WAF=<titles or "none">
+
+## Summary
+[2–4 sentences: what the indicator is, what behaviour was observed, overall risk read]
+
+---
+
+## IDS Findings
+**Total alerts:** N | **Blocked:** N | **Allowed (active):** N
+
+Top signatures:
+| Signature | Count | Severity |
+|---|---|---|
+
+MITRE coverage:
+| Tactic | Technique | Count |
+|---|---|---|
+
+Top peer IPs:
+| Direction | IP | Count |
+|---|---|---|
+| As source → dest | x[.]x[.]x[.]x | N |
+| As dest ← src | x[.]x[.]x[.]x | N |
+
+Top protocols: | app_proto | Count |
+
+Sample events (up to 5):
+`[timestamp] srcip → dstip:port | signature | action`
+
+---
+
+## NGFW Findings
+**Total events:** N | **THREAT:** N | **TRAFFIC:** N | **URL:** N
+
+Actions: | Action | Count |
+
+Top applications: | app | Count |
+
+Threat categories: | thr_category | Count |
+
+Rules triggered: | rule | Count |
+
+Users seen: | srcuser | Count |
+
+Sample events (up to 5):
+`[timestamp] srcip → dstip:dport | action | app | type/subtype | severity`
+
+---
+
+## Proxy Findings
+**Total requests:** N
+
+| URL category | Count | | Risk level | Count | | HTTP status | Count |
+
+Top user agents: | agent | Count |
+
+Sample URLs (up to 5):
+`[timestamp] srcip → uri | risk | response`
+
+---
+
+## WAF Findings
+**Total events:** N | **Blocked:** N | **Detected:** N
+
+| OWASP Rule ID | Count | Severity | Match |
+
+Attacker IPs (X-Forwarded-For): | ip | Count |
+
+---
+
+## Alert Events
+[Triggered Graylog alert definition names and counts, or "None found"]
+
+---
+
+## Activity Timeline
+[Histogram narrative: sustained / spike / periodic / one-shot. Peak time window. First seen. Last seen.
+State explicitly if a regular-interval beaconing pattern was detected.]
+
+---
+
+## Auto-Pivot: <pivot indicator>
+[3 sentences on findings. Omit this section entirely if no pivot was performed.]
+
+---
+
+## Assessment
+
+| Field | Value |
+|---|---|
+| **Risk Tier** | T1 — Critical / T2 — High / T3 — Medium / T4 — Low / T5 — Benign |
+| **Primary behaviour** | [Plain-language description] |
+| **Confidence** | High / Medium / Low |
+| **MITRE ATT&CK** | Tactic: Technique (TXXXX) — or "Not mapped" |
+| **Data sources hit** | IDS / NGFW / Proxy / WAF / Events |
+| **Recommended action** | Block at NGFW / Escalate to T2 / Open IRIS case / Monitor / Close as benign |
+| **Proposed IRIS severity** | Critical / High / Medium / Low — if opening a case |
+```

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: investigate
+description: Investigate any indicator (IP, hash, process name, or string) across Graylog and IRIS — auto-detects type, resolves stream IDs, runs targeted per-stream queries, applies analyst heuristics, and auto-pivots on the highest-risk finding.
+---
+
+Investigate the indicator: $ARGUMENTS
+
+Expected format: `<indicator> [last <N> days]`
+Default time window: last 14 days. Convert to `range_seconds` for all MCP calls.
+
+Examples:
+  `/investigate 192.168.1.100`
+  `/investigate 4d5f3b9a8c1e2d3f4e5a6b7c8d9e0f1a`
+  `/investigate mimikatz.exe`
+  `/investigate jdoe last 7 days`
+
+---
+
+## Phase 0 — Discover and map streams
+
+Call `list_streams()` once. Read every stream title returned.
+
+Stream names in this environment are company/client names — there are no generic
+names like "firewall" or "proxy". You must infer what each stream contains from
+context clues in the title, description, and index set name.
+
+Map each stream to one of these roles based on what you know about the environment:
+
+| Role | What to look for in the title/description |
+|---|---|
+| `fw_id` | Network traffic, firewall, perimeter, NAT, VPN, router, NGFW logs |
+| `proxy_id` | Web proxy, URL filtering, DNS, HTTP/HTTPS traffic, Squid, Zscaler |
+| `edr_id` | Endpoint, EDR, AV, CrowdStrike, Defender, Sysmon, process events |
+
+Rules:
+- A stream may cover more than one role — assign it to the most specific one.
+- If no stream clearly maps to a role, set that role's id to `None` and omit
+  `stream_id` from queries that would have used it (fall back to all streams).
+- If the indicator type makes a role irrelevant (e.g. hash investigation doesn't
+  need `proxy_id`), skip resolving that role entirely.
+- Print the resolved mapping before proceeding so the analyst can verify:
+  `Streams: fw=<title>, proxy=<title>, edr=<title>`
+
+Store the resolved ids as `fw_id`, `proxy_id`, `edr_id` and use them throughout Phase 2.
+
+---
+
+## Phase 1 — Classify the indicator
+
+| Pattern | Type |
+|---|---|
+| Matches `\d{1,3}(\.\d{1,3}){3}` | **IPv4** |
+| Exactly 32 hex chars | **MD5 hash** |
+| Exactly 40 hex chars | **SHA1 hash** |
+| Exactly 64 hex chars | **SHA256 hash** |
+| Ends in `.exe .dll .ps1 .bat .vbs .sh .py` | **Process / file name** |
+| Anything else | **Generic string** (username, hostname, command fragment, domain, IOC string) |
+
+---
+
+## Phase 2 — Run queries
+
+> Field names vary between Graylog deployments. If a query returns 0 results,
+> retry with the next field name variant before giving up.
+
+### IP investigation
+
+Run all of the following **in parallel**:
+
+**Outbound (IP as source)** — scoped to `fw_id` — try `srcip`, `src_ip`, `source_ip` until one returns results:
+- `search_terms(field="dstip",   query='srcip:"<ip>"', range_seconds=N, size=20, stream_id=fw_id)` — top destination IPs
+- `search_terms(field="dport",   query='srcip:"<ip>"', range_seconds=N, size=20, stream_id=fw_id)` — top destination ports
+- `search_terms(field="action",  query='srcip:"<ip>"', range_seconds=N, size=10, stream_id=fw_id)` — firewall actions
+- `search_terms(field="srcuser", query='srcip:"<ip>"', range_seconds=N, size=10, stream_id=fw_id)` — users at this source
+
+**Inbound (IP as destination)** — scoped to `fw_id` — try `dstip`, `dst_ip`, `destination_ip`:
+- `search_terms(field="srcip",  query='dstip:"<ip>"', range_seconds=N, size=20, stream_id=fw_id)` — top source IPs
+- `search_terms(field="action", query='dstip:"<ip>"', range_seconds=N, size=10, stream_id=fw_id)` — firewall actions
+
+**Proxy / DNS** — scoped to `proxy_id` — try `src_ip`, `client_ip`, `srcip`:
+- `search_terms(field="dst_domain",  query='src_ip:"<ip>" OR client_ip:"<ip>"', range_seconds=N, size=20, stream_id=proxy_id)` — domains accessed
+- `search_terms(field="http_status", query='src_ip:"<ip>" OR client_ip:"<ip>"', range_seconds=N, size=10, stream_id=proxy_id)` — HTTP status codes
+
+**Timeline** — scoped to `fw_id` (proxy_id as fallback):
+- `search_histogram(query='srcip:"<ip>" OR dstip:"<ip>" OR src_ip:"<ip>" OR dst_ip:"<ip>"', range_seconds=N, interval=<auto>, stream_id=fw_id)` — activity over time (minute if ≤1h, hour if ≤24h, day otherwise)
+
+**Recent raw events** — scoped to `fw_id`:
+- `search_relative(query='srcip:"<ip>" OR dstip:"<ip>"', range_seconds=N, limit=15, fields="timestamp,srcip,dstip,dport,action,srcuser,dst_domain", stream_id=fw_id)`
+
+**Alerts** (no stream filter — search all):
+- `search_events(query="<ip>", timerange_from=N)`
+
+**IRIS**:
+- `list_cases()` — scan case titles and descriptions for this IP
+
+---
+
+### Hash investigation
+
+Build a compound query:
+```
+hash_query = 'hash:"<hash>" OR md5:"<hash>" OR sha256:"<hash>" OR sha1:"<hash>" OR file_hash:"<hash>" OR FileHash:"<hash>"'
+```
+
+All queries scoped to `edr_id`. Run **in parallel**:
+- `search_terms(field="hostname",       query=hash_query, range_seconds=N, size=20, stream_id=edr_id)`
+- `search_terms(field="username",       query=hash_query, range_seconds=N, size=20, stream_id=edr_id)`
+- `search_terms(field="process_name",   query=hash_query, range_seconds=N, size=10, stream_id=edr_id)`
+- `search_terms(field="parent_process", query=hash_query, range_seconds=N, size=10, stream_id=edr_id)`
+- `search_terms(field="process_path",   query=hash_query, range_seconds=N, size=10, stream_id=edr_id)`
+- `search_histogram(query=hash_query, range_seconds=N, interval=<auto>, stream_id=edr_id)`
+- `search_relative(query=hash_query, range_seconds=N, limit=20, fields="timestamp,hostname,username,process_name,parent_process,process_path,command_line", stream_id=edr_id)`
+- `search_relative(query=hash_query, range_seconds=N, limit=10, fields="timestamp,hostname,dst_ip,dport,protocol", stream_id=edr_id)` — network connections
+- `search_events(query="<hash>", timerange_from=N)` — alerts (no stream filter)
+- `list_cases()` — IRIS lookup
+
+---
+
+### Process / file name investigation
+
+```
+proc_query = 'process_name:"<name>" OR process:"<name>" OR cmd:"<name>" OR OriginalFileName:"<name>" OR Image:"<name>"'
+```
+
+All queries scoped to `edr_id`. Run **in parallel**:
+- `search_terms(field="hostname",       query=proc_query, range_seconds=N, size=20, stream_id=edr_id)`
+- `search_terms(field="username",       query=proc_query, range_seconds=N, size=20, stream_id=edr_id)`
+- `search_terms(field="parent_process", query=proc_query, range_seconds=N, size=10, stream_id=edr_id)`
+- `search_terms(field="process_path",   query=proc_query, range_seconds=N, size=10, stream_id=edr_id)`
+- `search_terms(field="hash",           query=proc_query, range_seconds=N, size=10, stream_id=edr_id)`
+- `search_histogram(query=proc_query, range_seconds=N, interval=<auto>, stream_id=edr_id)`
+- `search_relative(query=proc_query, range_seconds=N, limit=20, fields="timestamp,hostname,username,process_name,parent_process,process_path,command_line,hash", stream_id=edr_id)`
+- `search_events(query="<name>", timerange_from=N)` — alerts (no stream filter)
+- `list_cases()` — IRIS lookup
+
+---
+
+### Generic string investigation
+
+No stream scoping — search all streams (indicator could appear anywhere):
+- `search_relative(query='"<indicator>"', range_seconds=N, limit=50)`
+- `search_terms(field="source",           query='"<indicator>"', range_seconds=N, size=20)`
+- `search_terms(field="application_name", query='"<indicator>"', range_seconds=N, size=10)`
+- `search_histogram(query='"<indicator>"', range_seconds=N, interval=<auto>)`
+- `search_events(query="<indicator>", timerange_from=N)`
+- `list_cases()` — IRIS lookup
+
+---
+
+## Phase 3 — Apply analyst heuristics (silently, before writing the report)
+
+### IP heuristics
+
+| Signal | Interpretation |
+|---|---|
+| Destination ports 3333, 4444, 5555, 1337, 14444, 4899 | Likely C2 or crypto mining — flag as high risk |
+| Port 22 to many unique destination IPs | Potential SSH scanner |
+| Port 443/80 at high, regular frequency to single external IP | HTTPS C2 beaconing |
+| Histogram shows consistent interval (every N min/hours) | Beaconing pattern — strongest C2 signal |
+| Action = DENY but count > 100 | Blocked but persistent — still investigate |
+| Activity concentrated between 22:00–06:00 | Off-hours — suspicious for workstations |
+| Internal RFC1918 source → external non-standard ports | Likely infected workstation |
+| Many unique source IPs → this destination | Host under scan, or public-facing server |
+
+### Hash / process heuristics
+
+| Signal | Interpretation |
+|---|---|
+| Same hash on 3+ hosts | Spreading / lateral movement — escalate immediately |
+| Running as SYSTEM or Administrator | Privilege abuse or malware with elevated rights |
+| Execution path contains `\Temp\`, `\AppData\`, `\Public\`, `\Downloads\` | Staged payload / evasion |
+| Parent is `cmd.exe`, `powershell.exe`, `wscript.exe`, `mshta.exe`, `regsvr32.exe` | Script-based execution chain — high suspicion |
+| Same hash on one host multiple times | Persistence mechanism |
+| Process makes outbound 443 connections | HTTPS C2 — cross-reference destination IPs |
+| Process name matches known LOLBin (`rundll32`, `msiexec`, `certutil`, `bitsadmin`) | Living-off-the-land technique |
+
+---
+
+## Phase 4 — Auto-pivot (maximum 1 level, highest-risk lead only)
+
+Pick the single most suspicious new lead found in Phase 2/3 and investigate it.
+Do not pivot more than once. Note other leads as "further investigation recommended."
+
+| Situation | Auto-pivot action |
+|---|---|
+| IP investigation reveals a specific **username** | `search_relative(query='username:"<user>" OR srcuser:"<user>"', range_seconds=N, limit=30, fields="timestamp,srcip,dstip,dport,action,hostname", stream_id=fw_id)` — summarise in 2–3 sentences |
+| IP investigation reveals **suspicious destination domain** (DGA-like, new TLD, typosquat) | `search_relative(query='dst_domain:"<domain>"', range_seconds=N, limit=20, stream_id=proxy_id)` — find all hosts that contacted it |
+| Hash on **3+ hosts** | Take the earliest-hit host → `search_relative(query='hostname:"<host>"', range_seconds=3600, limit=30, fields="timestamp,process_name,parent_process,username,command_line", stream_id=edr_id)` in ±1h around first detection |
+| Process shows **unusual parent** | Re-run process investigation on the parent name, scoped to `edr_id` |
+
+---
+
+## Phase 5 — Write the report
+
+Defang all external IPs and domains (replace `.` with `[.]`).
+
+```
+**Indicator:** `<indicator>` | **Type:** <IPv4 / MD5 / SHA256 / Process / String> | **Period:** <from> → <to>
+**Streams:** firewall=<title or "all">, proxy=<title or "all">, edr=<title or "all">
+
+**Summary**
+[2–3 sentences: what this indicator is, what it appears to be doing, overall risk read]
+
+---
+
+### Traffic Profile   ← (IP only)
+**Outbound** — N total events as source
+| Destination IP | Count |   | Top Port | Count |   | Action | Count |   | User | Count |
+
+**Inbound** — N total events as destination
+| Source IP | Count |   | Action | Count |
+
+**Proxy / DNS activity**
+| Domain accessed | Count |
+
+---
+
+### Execution Profile   ← (hash / process only)
+**Scope** — N unique hosts, N unique users
+| Host | Count |   | User | Count |   | Process name | Count |
+
+**Execution context**
+| Parent process | Count |   | Execution path | Count |
+
+**Network connections from process**
+| Destination IP | Port | Count |
+
+---
+
+### Activity Timeline
+[Summarise the histogram: sustained vs spike, peak time window, first/last event]
+
+---
+
+### Alerts
+[Triggered alert definition names and counts, or "None found"]
+
+---
+
+### IRIS Cases
+[Matching open cases by ID and title, or "No matching cases found"]
+
+---
+
+### Auto-Pivot: <indicator pivoted to>
+[2–3 sentences on findings. Omit if no pivot was performed.]
+
+---
+
+### Assessment
+
+| Field | Value |
+|---|---|
+| **Risk Tier** | T1 — Critical / T2 — High / T3 — Medium / T4 — Low / T5 — Benign |
+| **Behaviour** | [Plain-language description] |
+| **Confidence** | High / Medium / Low |
+| **MITRE ATT&CK** | [Technique ID + name, or "Not mapped"] |
+| **Recommended action** | Block at firewall / Escalate to T2 / Open IRIS case / Monitor / Close as benign |
+```


### PR DESCRIPTION
## Summary

- Adds `skills/graylog-hunt/SKILL.md` — multi-phase threat hunting skill for SOC analysts
- Adds `skills/investigate/SKILL.md` — investigation skill for drilling into a specific host/IP/user
- Adds `skills/graylog-hunt/README.md` — usage guide

All tool call examples have been updated to use the native Graylog 6.1+ MCP tool names:
- `aggregate_terms` / `aggregate_histogram` → `aggregate_messages(groupings=[...])`
- `search_sync` → `search_messages(fields=[...], streams=[...])`
- Stream ID variables changed from comma-strings to Python lists

> **Stacked on:** PR #9 (`pr/7-native-remove`)

## Test plan

- [ ] Open the graylog-hunt skill and run a hunt — verify Phase 1 probe produces results
- [ ] Verify `aggregate_messages(groupings=[{"field":"program","limit":10}])` call works
- [ ] Verify `search_messages(fields=["timestamp","source","message"], streams=[...])` returns logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)