### PR TITLE
graylog-mcp: fix _post convention, dotenv path, stale connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+*.pyc
+.venv/

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -44,15 +44,15 @@ docker run -i --rm --network host \
 
 ## Tools
 
-### Search (Graylog 6.x — `views/search/sync`)
+### Search & Aggregation (Graylog 6.x — `views/search/sync`)
 
-> Use these tools on Graylog 6.x. The legacy search tools below return 0 results on 6.x.
+> Use these tools on Graylog 6.x. The legacy tools below return 0 results on 6.x.
+> Tool names and parameters match the [native Graylog 6.1+ MCP server](https://github.com/Graylog2/graylog2-server) for skill portability.
 
 | Tool | Description |
 |---|---|
-| `search_sync` | Search messages — replaces `search_relative`/`search_absolute` for Graylog 6.x |
-| `aggregate_terms` | Top-N field value counts via pivot — replaces `search_terms` for Graylog 6.x |
-| `aggregate_histogram` | Message count over time via pivot — replaces `search_histogram` for Graylog 6.x |
+| `search_messages` | Search messages — replaces `search_relative`/`search_absolute` for Graylog 6.x |
+| `aggregate_messages` | Group-by + metrics (top-N terms, histogram, any aggregation) — replaces `search_terms`/`search_histogram` for Graylog 6.x |
 
 ### Search (legacy — Graylog 4.x / 5.x only)
 
@@ -114,5 +114,5 @@ docker run -i --rm --network host \
 
 | Tool | Description |
 |---|---|
-| `system_overview` | Graylog system info (version, cluster, status) |
+| `get_system_status` | Graylog system info (version, cluster, hostname, timezone, status) |
 | `list_inputs` | List configured inputs |

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -114,5 +114,7 @@ docker run -i --rm --network host \
 
 | Tool | Description |
 |---|---|
+| `get_current_time` | Current UTC time — use to anchor relative time reasoning in skills |
 | `get_system_status` | Graylog system info (version, cluster, hostname, timezone, status) |
+| `list_fields` | Field names, types, and capabilities — scope to streams to reduce noise |
 | `list_inputs` | List configured inputs |

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -1,15 +1,17 @@
 # graylog-mcp
 
-MCP server for the Graylog REST API — log search, alerts, streams, and system info.
+MCP server for the Graylog REST API — log search, aggregations, alerts, pipelines, dashboards, and system info.
 
-> **Note:** Graylog 6.1+ ships a [built-in MCP server](https://github.com/Graylog2/graylog2-server). This server targets older Graylog versions (4.x / 5.x) that lack native MCP support.
+> **Note:** Graylog 6.1+ ships a [built-in MCP server](https://github.com/Graylog2/graylog2-server). This server targets Graylog 4.x / 5.x, but also works with 6.x where the built-in MCP is not available or preferred.
 
 ## Environment Variables
 
-| Variable | Required | Description |
-|---|---|---|
-| `GRAYLOG_URL` | yes | Graylog base URL (e.g. `http://localhost:9000`) |
-| `GRAYLOG_API_TOKEN` | yes | API token (create in System → Users → Tokens) |
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GRAYLOG_URL` | yes | — | Graylog base URL (e.g. `http://localhost:9000`) |
+| `GRAYLOG_API_TOKEN` | yes | — | API token (create in System → Users → Tokens) |
+| `GRAYLOG_VERIFY_SSL` | no | `true` | Set to `false` only for self-signed certs on trusted internal networks |
+| `LOG_LEVEL` | no | `WARNING` | Python log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 
 ## Run
 
@@ -28,7 +30,9 @@ docker run -i --rm --network host \
   "mcpServers": {
     "graylog": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "--network", "host", "-e", "GRAYLOG_URL", "-e", "GRAYLOG_API_TOKEN", "ghcr.io/gabrielbelli/graylog-mcp"],
+      "args": ["run", "-i", "--rm", "--network", "host",
+               "-e", "GRAYLOG_URL", "-e", "GRAYLOG_API_TOKEN",
+               "ghcr.io/gabrielbelli/graylog-mcp"],
       "env": {
         "GRAYLOG_URL": "http://localhost:9000",
         "GRAYLOG_API_TOKEN": ""
@@ -40,15 +44,75 @@ docker run -i --rm --network host \
 
 ## Tools
 
+### Search (Graylog 6.x — `views/search/sync`)
+
+> Use these tools on Graylog 6.x. The legacy search tools below return 0 results on 6.x.
+
 | Tool | Description |
 |---|---|
-| `search_relative` | Search messages with relative time range |
-| `search_absolute` | Search messages with absolute time range |
-| `search_keyword` | Search messages with natural language time range |
-| `get_message` | Retrieve a specific message by ID |
+| `search_sync` | Search messages — replaces `search_relative`/`search_absolute` for Graylog 6.x |
+| `aggregate_terms` | Top-N field value counts via pivot — replaces `search_terms` for Graylog 6.x |
+| `aggregate_histogram` | Message count over time via pivot — replaces `search_histogram` for Graylog 6.x |
+
+### Search (legacy — Graylog 4.x / 5.x only)
+
+| Tool | Description |
+|---|---|
+| `search_relative` | Search messages with relative time range (Lucene syntax) |
+| `search_absolute` | Search messages with absolute time range (ISO 8601) |
+| `search_keyword` | Search messages with natural language time range (e.g. "last 1 hour") |
+| `get_message` | Retrieve a specific message by ID and index |
+
+### Aggregations (legacy — Graylog 4.x / 5.x only)
+
+| Tool | Description |
+|---|---|
+| `search_terms` | Top-N values for a field (e.g. top source IPs, usernames, error codes) |
+| `search_stats` | Statistical summary for a numeric field (min, max, mean, sum, stddev) |
+| `search_histogram` | Message count bucketed over time — spot volume spikes or drops |
+| `search_field_histogram` | Numeric field value distribution over time |
+
+### Streams
+
+| Tool | Description |
+|---|---|
 | `list_streams` | List all streams |
 | `get_stream` | Get stream details |
-| `search_events` | Search alert events |
-| `list_event_definitions` | List alert/event definitions |
-| `system_overview` | Graylog system info |
+| `find_stream` | Find streams by name (case-insensitive substring match) |
+
+### Alerts & Events
+
+| Tool | Description |
+|---|---|
+| `search_events` | Search alert events with pagination |
+| `list_event_definitions` | List all alert/event definitions |
+
+### Pipelines
+
+> Requires the Graylog Processing Pipelines plugin (built-in since Graylog 4.x).
+
+| Tool | Description |
+|---|---|
+| `list_pipelines` | List all processing pipelines |
+| `get_pipeline` | Get pipeline details (stages, connected streams) |
+| `list_pipeline_rules` | List all pipeline rules |
+| `get_pipeline_rule` | Get rule source code and metadata |
+| `list_pipeline_connections` | Show which streams are connected to which pipelines |
+
+### Dashboards & Saved Searches
+
+> `list_saved_searches` and `get_saved_search` try the Graylog 5.x/6.x Views API first, and fall back to the 4.x saved search API automatically.
+
+| Tool | Description |
+|---|---|
+| `list_dashboards` | List all dashboards |
+| `get_dashboard` | Get a dashboard and its widget list |
+| `list_saved_searches` | List saved searches (version-agnostic) |
+| `get_saved_search` | Get a saved search by ID (version-agnostic) |
+
+### System
+
+| Tool | Description |
+|---|---|
+| `system_overview` | Graylog system info (version, cluster, status) |
 | `list_inputs` | List configured inputs |

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -72,20 +72,19 @@ docker run -i --rm --network host \
 | `search_histogram` | Message count bucketed over time — spot volume spikes or drops |
 | `search_field_histogram` | Numeric field value distribution over time |
 
-### Streams
+### Streams & Resources
 
 | Tool | Description |
 |---|---|
 | `list_streams` | List all streams |
-| `get_stream` | Get stream details |
-| `find_stream` | Find streams by name (case-insensitive substring match) |
+| `list_resource` | List streams, dashboards, or event definitions by type — returns GRNs |
+| `describe_resource` | Describe a specific resource by GRN (e.g. `grn::::stream:abc123`) |
 
 ### Alerts & Events
 
 | Tool | Description |
 |---|---|
 | `search_events` | Search alert events with pagination |
-| `list_event_definitions` | List all alert/event definitions |
 
 ### Pipelines
 
@@ -98,17 +97,6 @@ docker run -i --rm --network host \
 | `list_pipeline_rules` | List all pipeline rules |
 | `get_pipeline_rule` | Get rule source code and metadata |
 | `list_pipeline_connections` | Show which streams are connected to which pipelines |
-
-### Dashboards & Saved Searches
-
-> `list_saved_searches` and `get_saved_search` try the Graylog 5.x/6.x Views API first, and fall back to the 4.x saved search API automatically.
-
-| Tool | Description |
-|---|---|
-| `list_dashboards` | List all dashboards |
-| `get_dashboard` | Get a dashboard and its widget list |
-| `list_saved_searches` | List saved searches (version-agnostic) |
-| `get_saved_search` | Get a saved search by ID (version-agnostic) |
 
 ### System
 

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -12,6 +12,7 @@ MCP server for the Graylog REST API — log search, aggregations, alerts, pipeli
 | `GRAYLOG_API_TOKEN` | yes | — | API token (create in System → Users → Tokens) |
 | `GRAYLOG_VERIFY_SSL` | no | `true` | Set to `false` only for self-signed certs on trusted internal networks |
 | `LOG_LEVEL` | no | `WARNING` | Python log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `DOTENV_PATH` | no | `../../.env` relative to `server.py` | Override the `.env` file path for local development |
 
 ## Run
 

--- a/graylog-mcp/requirements.txt
+++ b/graylog-mcp/requirements.txt
@@ -1,2 +1,4 @@
 mcp[cli]>=1.0.0
 httpx>=0.27.0
+tenacity>=8.0.0
+python-dotenv>=1.0.0

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -733,10 +733,50 @@ def get_saved_search(search_id: str) -> dict:
 
 
 @mcp.tool()
+def get_current_time() -> dict:
+    """Get the current UTC time from the server.
+
+    Use this to anchor relative time reasoning. Without it, models tend to
+    infer current time from system start time and produce wrong durations.
+    """
+    from datetime import datetime, timezone
+    return {"current_time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")}
+
+
+@mcp.tool()
 def get_system_status() -> dict:
     """Get Graylog system information (version, cluster ID, hostname, timezone, status)."""
     try:
         return _get("/system")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def list_fields(streams: list[str] | None = None) -> dict:
+    """List available field names, types, and capabilities.
+
+    Field names differ per stream and over time. Use this before building
+    queries to discover which fields exist and what their types are.
+    Fields marked enumerable can be grouped in aggregate_messages.
+    Fields marked numeric support metric functions (avg, min, max, sum, etc).
+
+    Tries the Graylog 6.x /views/fields API first; falls back to /system/fields
+    for Graylog 4.x/5.x (which returns names only, without type metadata).
+
+    Args:
+        streams: Stream IDs to scope the field listing (empty = all accessible streams)
+    """
+    params: dict = {}
+    if streams:
+        params["streams[]"] = streams
+    try:
+        try:
+            return _get("/views/fields", params or None)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return _get("/system/fields")
+            raise
     except Exception as e:
         return _err(e)
 

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -4,29 +4,79 @@ Wraps the Graylog REST API and exposes search, streams, and alert endpoints
 as MCP tools for SOC workflows.
 """
 
+import logging
 import os
+from pathlib import Path
 
 import httpx
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
+logger = logging.getLogger("graylog-mcp")
 
 mcp = FastMCP("graylog")
 
 GRAYLOG_URL = os.environ.get("GRAYLOG_URL", "http://localhost:9000")
 GRAYLOG_API_TOKEN = os.environ.get("GRAYLOG_API_TOKEN", "")
+GRAYLOG_VERIFY_SSL = os.getenv("GRAYLOG_VERIFY_SSL", "true").lower() != "false"
+
+_http: httpx.Client | None = None
 
 
 def _client() -> httpx.Client:
-    return httpx.Client(
-        base_url=f"{GRAYLOG_URL}/api",
-        auth=(GRAYLOG_API_TOKEN, "token"),
-        headers={
-            "Accept": "application/json",
-            "X-Requested-By": "graylog-mcp",
-            "User-Agent": "graylog-mcp/1.0",
-        },
-        verify=False,
-        timeout=30,
-    )
+    global _http
+    if _http is None:
+        _http = httpx.Client(
+            base_url=f"{GRAYLOG_URL}/api",
+            auth=(GRAYLOG_API_TOKEN, "token"),
+            headers={
+                "Accept": "application/json",
+                "X-Requested-By": "graylog-mcp",
+                "User-Agent": "graylog-mcp/1.0",
+            },
+            verify=GRAYLOG_VERIFY_SSL,
+            timeout=30,
+        )
+    return _http
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _get(path: str, params: dict | None = None) -> dict:
+    logger.debug("GET %s params=%s", path, params)
+    r = _client().get(path, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _post(path: str, body: dict, params: dict | None = None) -> dict:
+    logger.debug("POST %s", path)
+    r = _client().post(path, json=body, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+def _err(e: Exception) -> dict:
+    if isinstance(e, httpx.HTTPStatusError):
+        return {
+            "error": f"HTTP {e.response.status_code}",
+            "url": str(e.request.url),
+            "detail": e.response.text[:500],
+        }
+    return {"error": type(e).__name__, "detail": str(e)}
 
 
 # ── Search ─────────────────────────────────────────────────────────────────
@@ -49,15 +99,15 @@ def search_relative(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "range": range_seconds, "limit": limit}
+    params: dict = {"query": query, "range": range_seconds, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/relative", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/relative", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -79,15 +129,15 @@ def search_absolute(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "from": from_time, "to": to_time, "limit": limit}
+    params: dict = {"query": query, "from": from_time, "to": to_time, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/absolute", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/absolute", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -107,15 +157,15 @@ def search_keyword(
         fields: Comma-separated list of fields to return (empty = all)
         stream_id: Limit search to a specific stream ID (optional)
     """
-    params = {"query": query, "keyword": keyword, "limit": limit}
+    params: dict = {"query": query, "keyword": keyword, "limit": limit}
     if fields:
         params["fields"] = fields
     if stream_id:
         params["filter"] = f"streams:{stream_id}"
-    with _client() as c:
-        r = c.get("/search/universal/keyword", params=params)
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/search/universal/keyword", params)
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -126,10 +176,10 @@ def get_message(message_id: str, index: str) -> dict:
         message_id: The message ID
         index: The Elasticsearch index containing the message
     """
-    with _client() as c:
-        r = c.get(f"/messages/{index}/{message_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/messages/{index}/{message_id}")
+    except Exception as e:
+        return _err(e)
 
 
 # ── Streams ────────────────────────────────────────────────────────────────
@@ -138,10 +188,10 @@ def get_message(message_id: str, index: str) -> dict:
 @mcp.tool()
 def list_streams() -> dict:
     """List all streams configured in Graylog."""
-    with _client() as c:
-        r = c.get("/streams")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/streams")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -151,10 +201,10 @@ def get_stream(stream_id: str) -> dict:
     Args:
         stream_id: The stream ID
     """
-    with _client() as c:
-        r = c.get(f"/streams/{stream_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/streams/{stream_id}")
+    except Exception as e:
+        return _err(e)
 
 
 # ── Alerts / Events ───────────────────────────────────────────────────────
@@ -175,27 +225,27 @@ def search_events(
         page: Page number (default: 1)
         per_page: Results per page (default: 50)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/events/search",
-            json={
+            {
                 "query": query,
                 "timerange": {"type": "relative", "range": timerange_from},
                 "page": page,
                 "per_page": per_page,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
 def list_event_definitions() -> dict:
     """List all event/alert definitions configured in Graylog."""
-    with _client() as c:
-        r = c.get("/events/definitions")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/events/definitions")
+    except Exception as e:
+        return _err(e)
 
 
 # ── System ─────────────────────────────────────────────────────────────────
@@ -204,19 +254,19 @@ def list_event_definitions() -> dict:
 @mcp.tool()
 def system_overview() -> dict:
     """Get Graylog system overview (version, cluster, status)."""
-    with _client() as c:
-        r = c.get("/system")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/system")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
 def list_inputs() -> dict:
     """List all configured inputs in Graylog."""
-    with _client() as c:
-        r = c.get("/system/inputs")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/system/inputs")
+    except Exception as e:
+        return _err(e)
 
 
 if __name__ == "__main__":

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -93,10 +93,6 @@ def _build_filter(stream_ids: list[str]) -> dict | None:
     return {"type": "or", "filters": filters}
 
 
-def _parse_stream_ids(stream_ids: str) -> list[str]:
-    return [s.strip() for s in stream_ids.split(",") if s.strip()]
-
-
 def _sync_search(body: dict, timeout_ms: int) -> dict:
     return _post("/views/search/sync", body, params={"timeout": timeout_ms})
 
@@ -204,55 +200,58 @@ def get_message(message_id: str, index: str) -> dict:
         return _err(e)
 
 
-# ── Search (Graylog 6.x — views/search/sync) ──────────────────────────────
+# ── Search & Aggregation (Graylog 6.x — views/search/sync) ────────────────
 
 
 @mcp.tool()
-def search_sync(
+def search_messages(
     query: str,
+    streams: list[str] | None = None,
+    stream_categories: list[str] | None = None,
+    fields: list[str] | None = None,
+    limit: int = 50,
+    offset: int = 0,
     range_seconds: int = 86400,
     from_time: str = "",
     to_time: str = "",
-    limit: int = 50,
-    fields: str = "",
-    stream_ids: str = "",
     sort_field: str = "timestamp",
     sort_order: str = "DESC",
     timeout_ms: int = 15000,
 ) -> dict:
-    """Search Graylog 6.x messages using the views/search/sync API.
+    """Search Graylog 6.x messages.
 
     Use this instead of search_relative or search_absolute on Graylog 6.x.
     The legacy /search/universal/* endpoints return no results on Graylog 6.x.
 
+    Pass the timerange via range_seconds or from_time+to_time — never embed time
+    in the query string. List only the fields you need; without fields, only
+    source and timestamp are returned. Scope to specific streams for performance.
+
     Args:
         query: Lucene query string (e.g. 'srcip:"1.2.3.4"', 'alert_severity:1')
-        range_seconds: Relative time window in seconds (default 86400 = 24h).
-                       Ignored when from_time and to_time are both set.
+        streams: Stream IDs to scope the search (empty = all streams)
+        stream_categories: Illuminate stream categories — Graylog 6.x with Illuminate only
+        fields: Field names to return. Empty = source and timestamp only.
+        limit: Maximum messages to return (default 50)
+        offset: Pagination offset (default 0)
+        range_seconds: Relative lookback in seconds (default 86400 = 24h).
+                       Ignored when from_time and to_time are both provided.
         from_time: Absolute start time ISO 8601 (e.g. 2025-04-01T00:00:00.000Z).
-                   Provide together with to_time to use an absolute range.
         to_time: Absolute end time ISO 8601.
-        limit: Maximum number of messages to return (default 50)
-        fields: Comma-separated field names to include in each message.
-                Empty string returns all stored fields.
-        stream_ids: Comma-separated stream IDs to scope the search.
-                    Empty string searches across all streams.
         sort_field: Field to sort by (default: timestamp)
         sort_order: ASC or DESC (default: DESC)
         timeout_ms: Server-side query timeout in milliseconds (default 15000)
     """
     try:
-        sid_list = _parse_stream_ids(stream_ids)
-        fields_list = [f.strip() for f in fields.split(",") if f.strip()]
         search_type: dict = {
             "id": "msgs",
             "type": "messages",
             "limit": limit,
-            "offset": 0,
+            "offset": offset,
             "sort": [{"field": sort_field, "order": sort_order}],
         }
-        if fields_list:
-            search_type["fields"] = fields_list
+        if fields:
+            search_type["fields"] = fields
 
         query_obj: dict = {
             "id": str(uuid.uuid4()),
@@ -260,9 +259,9 @@ def search_sync(
             "timerange": _build_timerange(range_seconds, from_time, to_time),
             "search_types": [search_type],
         }
-        f = _build_filter(sid_list)
-        if f:
-            query_obj["filter"] = f
+        flt = _build_filter(streams or [])
+        if flt:
+            query_obj["filter"] = flt
 
         raw = _sync_search({"queries": [query_obj]}, timeout_ms)
         qid = query_obj["id"]
@@ -278,85 +277,47 @@ def search_sync(
 
 
 @mcp.tool()
-def aggregate_terms(
-    field: str,
+def aggregate_messages(
+    groupings: list[dict],
+    metrics: list[dict] | None = None,
     query: str = "*",
-    range_seconds: int = 86400,
+    streams: list[str] | None = None,
+    stream_categories: list[str] | None = None,
+    range_seconds: int = 3600,
     from_time: str = "",
     to_time: str = "",
-    size: int = 20,
-    stream_ids: str = "",
     timeout_ms: int = 15000,
 ) -> dict:
-    """Get top-N values for a field using the Graylog 6.x views/search/sync API.
+    """Aggregate and group Graylog 6.x messages by field values or time buckets.
 
-    Use this instead of search_terms on Graylog 6.x.
+    Use this instead of search_terms or search_histogram on Graylog 6.x.
 
-    Args:
-        field: Field name to aggregate (e.g. "dstip", "alert_signature", "srcuser")
-        query: Lucene filter query (default: all messages)
-        range_seconds: Relative time window in seconds (default 86400 = 24h)
-        from_time: Absolute start time ISO 8601. Pair with to_time for absolute range.
-        to_time: Absolute end time ISO 8601.
-        size: Number of top values to return (default 20)
-        stream_ids: Comma-separated stream IDs. Empty = all streams.
-        timeout_ms: Server-side timeout in milliseconds (default 15000)
-    """
-    try:
-        sid_list = _parse_stream_ids(stream_ids)
-        search_type = {
-            "id": "terms_0",
-            "type": "pivot",
-            "row_groups": [{"type": "values", "field": field, "limit": size}],
-            "column_groups": [],
-            "series": [{"type": "count", "id": "count", "field": None}],
-            "rollup": False,
-        }
-        query_obj: dict = {
-            "id": str(uuid.uuid4()),
-            "query": {"type": "elasticsearch", "query_string": query},
-            "timerange": _build_timerange(range_seconds, from_time, to_time),
-            "search_types": [search_type],
-        }
-        f = _build_filter(sid_list)
-        if f:
-            query_obj["filter"] = f
+    Each grouping is either a field-value bucket or a time bucket:
+      {"field": "source", "limit": 10}               — top-N values for a field
+      {"field": "timestamp", "granularity": "hour"}   — time histogram
 
-        raw = _sync_search({"queries": [query_obj]}, timeout_ms)
-        qid = query_obj["id"]
-        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("terms_0", {})
-        terms = [
-            {"value": row["key"][0], "count": row["values"][0].get("value", 0)}
-            for row in st.get("rows", [])
-            if row.get("key")
-        ]
-        return {"field": field, "terms": terms}
-    except Exception as e:
-        return _err(e)
+    granularity options: "auto", "minute", "hour", "day", "week", "month"
 
+    Each metric defines what to compute per bucket:
+      {"function": "count"}                    — message count (default)
+      {"function": "avg", "field": "bytes"}    — numeric field metric
 
-@mcp.tool()
-def aggregate_histogram(
-    query: str = "*",
-    range_seconds: int = 86400,
-    from_time: str = "",
-    to_time: str = "",
-    interval: str = "auto",
-    stream_ids: str = "",
-    timeout_ms: int = 15000,
-) -> dict:
-    """Get message count bucketed over time using the Graylog 6.x views/search/sync API.
+    metric functions: count, avg, min, max, sum, stddev, card, latest
 
-    Use this instead of search_histogram on Graylog 6.x.
+    Examples:
+      Top 10 sources:  groupings=[{"field":"source","limit":10}], metrics=[{"function":"count"}]
+      Hourly volume:   groupings=[{"field":"timestamp","granularity":"hour"}], metrics=[{"function":"count"}]
+      Avg bytes/dest:  groupings=[{"field":"dstip","limit":20}], metrics=[{"function":"avg","field":"bytes"}]
 
     Args:
+        groupings: Required. One or more grouping dicts.
+        metrics: Metric dicts. Defaults to [{"function": "count"}].
         query: Lucene filter query (default: all messages)
-        range_seconds: Relative time window in seconds (default 86400 = 24h)
+        streams: Stream IDs to scope the search (empty = all streams)
+        stream_categories: Illuminate stream categories — Graylog 6.x with Illuminate only
+        range_seconds: Relative time window in seconds (default 3600 = 1 hour)
         from_time: Absolute start time ISO 8601. Pair with to_time for absolute range.
         to_time: Absolute end time ISO 8601.
-        interval: Bucket size — "auto", "minute", "hour", "day", "week", "month".
-                  "auto" lets Graylog choose based on the time range.
-        stream_ids: Comma-separated stream IDs. Empty = all streams.
         timeout_ms: Server-side timeout in milliseconds (default 15000)
     """
     _UNIT_MAP = {
@@ -367,26 +328,45 @@ def aggregate_histogram(
         "month": "MONTHS", "months": "MONTHS",
     }
     try:
-        sid_list = _parse_stream_ids(stream_ids)
-        if interval == "auto":
-            row_group = {
-                "type": "time",
-                "field": "timestamp",
-                "interval": {"type": "auto", "scaling": 1.0},
-            }
-        else:
-            unit = _UNIT_MAP.get(interval.lower(), "HOURS")
-            row_group = {
-                "type": "time",
-                "field": "timestamp",
-                "interval": {"type": "timeunit", "value": 1, "unit": unit},
-            }
+        row_groups = []
+        for g in groupings:
+            field = g.get("field", "")
+            if field == "timestamp" or "granularity" in g:
+                gran = g.get("granularity", "auto")
+                if gran == "auto":
+                    row_groups.append({
+                        "type": "time",
+                        "field": "timestamp",
+                        "interval": {"type": "auto", "scaling": 1.0},
+                    })
+                else:
+                    unit = _UNIT_MAP.get(gran.lower(), "HOURS")
+                    row_groups.append({
+                        "type": "time",
+                        "field": "timestamp",
+                        "interval": {"type": "timeunit", "value": 1, "unit": unit},
+                    })
+            else:
+                row_groups.append({
+                    "type": "values",
+                    "field": field,
+                    "limit": g.get("limit", 10),
+                })
+
+        series = []
+        for i, m in enumerate(metrics or [{"function": "count"}]):
+            fn = m["function"].lower()
+            s: dict = {"type": fn, "id": f"{fn}_{i}"}
+            if "field" in m:
+                s["field"] = m["field"]
+            series.append(s)
+
         search_type = {
-            "id": "hist_0",
+            "id": "agg_0",
             "type": "pivot",
-            "row_groups": [row_group],
+            "row_groups": row_groups,
             "column_groups": [],
-            "series": [{"type": "count", "id": "count", "field": None}],
+            "series": series,
             "rollup": False,
         }
         query_obj: dict = {
@@ -395,19 +375,25 @@ def aggregate_histogram(
             "timerange": _build_timerange(range_seconds, from_time, to_time),
             "search_types": [search_type],
         }
-        f = _build_filter(sid_list)
-        if f:
-            query_obj["filter"] = f
+        flt = _build_filter(streams or [])
+        if flt:
+            query_obj["filter"] = flt
 
         raw = _sync_search({"queries": [query_obj]}, timeout_ms)
         qid = query_obj["id"]
-        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("hist_0", {})
-        buckets = [
-            {"timestamp": row["key"][0], "count": row["values"][0].get("value", 0)}
+        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("agg_0", {})
+        rows = [
+            {
+                "key": row.get("key", []),
+                "values": {
+                    v.get("id", f"v{i}"): v.get("value")
+                    for i, v in enumerate(row.get("values", []))
+                },
+            }
             for row in st.get("rows", [])
             if row.get("key")
         ]
-        return {"interval": interval, "buckets": buckets}
+        return {"groupings": [g.get("field") for g in groupings], "rows": rows}
     except Exception as e:
         return _err(e)
 
@@ -747,8 +733,8 @@ def get_saved_search(search_id: str) -> dict:
 
 
 @mcp.tool()
-def system_overview() -> dict:
-    """Get Graylog system overview (version, cluster, status)."""
+def get_system_status() -> dict:
+    """Get Graylog system information (version, cluster ID, hostname, timezone, status)."""
     try:
         return _get("/system")
     except Exception as e:

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -522,46 +522,89 @@ def list_streams() -> dict:
         return _err(e)
 
 
+# ── Resources (streams, dashboards, event definitions) ────────────────────
+
+
 @mcp.tool()
-def get_stream(stream_id: str) -> dict:
-    """Get details for a specific stream.
+def list_resource(resource_type: str) -> dict:
+    """List Graylog resources of a given type, returning GRNs and names.
+
+    The GRN (Graylog Resource Name) returned for each item can be passed to
+    describe_resource to fetch its full details.
 
     Args:
-        stream_id: The stream ID
+        resource_type: One of "stream", "dashboard", "event_definition"
     """
+    t = resource_type.lower().removesuffix("s").replace(" ", "_")
     try:
-        return _get(f"/streams/{stream_id}")
+        if t == "stream":
+            data = _get("/streams")
+            return {
+                "resources": [
+                    {
+                        "grn": f"grn::::stream:{s['id']}",
+                        "name": s.get("title", ""),
+                        "description": s.get("description", ""),
+                        "disabled": s.get("disabled", False),
+                    }
+                    for s in data.get("streams", [])
+                ]
+            }
+        elif t == "dashboard":
+            data = _get("/views", {"type": "DASHBOARD", "page": 1, "per_page": 100})
+            return {
+                "resources": [
+                    {
+                        "grn": f"grn::::dashboard:{v['id']}",
+                        "name": v.get("title", ""),
+                        "description": v.get("description", ""),
+                    }
+                    for v in data.get("views", [])
+                ]
+            }
+        elif t in ("event_definition", "eventdefinition", "eventdef"):
+            data = _get("/events/definitions", {"page": 1, "per_page": 100})
+            return {
+                "resources": [
+                    {
+                        "grn": f"grn::::event_definition:{e['id']}",
+                        "name": e.get("title", ""),
+                        "description": e.get("description", ""),
+                    }
+                    for e in data.get("event_definitions", [])
+                ]
+            }
+        else:
+            return {"error": f"Unknown resource_type '{resource_type}'. Use: stream, dashboard, event_definition"}
     except Exception as e:
         return _err(e)
 
 
 @mcp.tool()
-def find_stream(name: str) -> dict:
-    """Find streams whose title matches a name (case-insensitive substring match).
+def describe_resource(grn: str) -> dict:
+    """Describe a specific Graylog resource by its GRN.
 
-    Call this at the start of an investigation to resolve a human-readable stream
-    name (e.g. "firewall", "proxy", "edr", "windows") into its Graylog stream ID.
-    Pass the returned id as stream_id to any search tool to scope queries to that
-    stream only instead of searching across all streams.
+    The GRN is the identifier returned by list_resource.
+    Format: grn::::TYPE:ID  e.g. grn::::stream:abc123
 
     Args:
-        name: Partial or full stream title to search for (e.g. "firewall", "proxy", "edr")
+        grn: Graylog Resource Name (e.g. grn::::stream:abc123)
     """
+    parts = grn.split(":")
+    # GRN format: "grn::::TYPE:ID" → ["grn", "", "", "", "TYPE", "ID"]
+    if len(parts) < 6 or parts[0] != "grn":
+        return {"error": f"Invalid GRN format: {grn!r}. Expected: grn::::TYPE:ID"}
+    grn_type = parts[4]
+    entity_id = ":".join(parts[5:])
     try:
-        result = _get("/streams")
-        streams = result.get("streams", [])
-        name_lower = name.lower()
-        matches = [
-            {
-                "id": s.get("id"),
-                "title": s.get("title"),
-                "description": s.get("description", ""),
-                "disabled": s.get("disabled", False),
-            }
-            for s in streams
-            if name_lower in s.get("title", "").lower()
-        ]
-        return {"query": name, "matches": matches, "total": len(matches)}
+        if grn_type == "stream":
+            return _get(f"/streams/{entity_id}")
+        elif grn_type == "dashboard":
+            return _get(f"/views/{entity_id}")
+        elif grn_type in ("event_definition", "eventdef"):
+            return _get(f"/events/definitions/{entity_id}")
+        else:
+            return {"error": f"Unsupported GRN type: {grn_type!r}"}
     except Exception as e:
         return _err(e)
 
@@ -594,15 +637,6 @@ def search_events(
                 "per_page": per_page,
             },
         )
-    except Exception as e:
-        return _err(e)
-
-
-@mcp.tool()
-def list_event_definitions() -> dict:
-    """List all event/alert definitions configured in Graylog."""
-    try:
-        return _get("/events/definitions")
     except Exception as e:
         return _err(e)
 
@@ -662,71 +696,6 @@ def list_pipeline_connections() -> dict:
     except Exception as e:
         return _err(e)
 
-
-# ── Dashboards & Saved Searches ────────────────────────────────────────────
-
-
-@mcp.tool()
-def list_dashboards() -> dict:
-    """List all dashboards in Graylog."""
-    try:
-        return _get("/dashboards")
-    except Exception as e:
-        return _err(e)
-
-
-@mcp.tool()
-def get_dashboard(dashboard_id: str) -> dict:
-    """Get a specific dashboard with its widget list.
-
-    Args:
-        dashboard_id: The dashboard ID
-    """
-    try:
-        return _get(f"/dashboards/{dashboard_id}")
-    except Exception as e:
-        return _err(e)
-
-
-@mcp.tool()
-def list_saved_searches() -> dict:
-    """List all saved searches.
-
-    Tries the Graylog 5.x/6.x Views API first, falls back to the 4.x saved search API.
-    """
-    try:
-        return _get("/search/views", {"type": "SEARCH"})
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            try:
-                return _get("/search/saved")
-            except Exception as e2:
-                return _err(e2)
-        return _err(e)
-    except Exception as e:
-        return _err(e)
-
-
-@mcp.tool()
-def get_saved_search(search_id: str) -> dict:
-    """Get a specific saved search by ID.
-
-    Tries the Graylog 5.x/6.x Views API first, falls back to the 4.x saved search API.
-
-    Args:
-        search_id: The saved search or view ID
-    """
-    try:
-        return _get(f"/search/views/{search_id}")
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            try:
-                return _get(f"/search/saved/{search_id}")
-            except Exception as e2:
-                return _err(e2)
-        return _err(e)
-    except Exception as e:
-        return _err(e)
 
 
 # ── System ─────────────────────────────────────────────────────────────────

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(os.getenv("DOTENV_PATH") or Path(__file__).parent.parent / ".env")
 logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
 logger = logging.getLogger("graylog-mcp")
 
@@ -44,10 +44,17 @@ def _client() -> httpx.Client:
     return _http
 
 
+def _reconnect(_retry_state) -> None:
+    """Drop the singleton client before each retry so a fresh connection is made."""
+    global _http
+    _http = None
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     retry=retry_if_exception_type(httpx.TransportError),
+    before_sleep=_reconnect,
     reraise=True,
 )
 def _get(path: str, params: dict | None = None) -> dict:
@@ -61,9 +68,10 @@ def _get(path: str, params: dict | None = None) -> dict:
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     retry=retry_if_exception_type(httpx.TransportError),
+    before_sleep=_reconnect,
     reraise=True,
 )
-def _post(path: str, body: dict, params: dict | None = None) -> dict:
+def _post(path: str, *, body: dict, params: dict | None = None) -> dict:
     logger.debug("POST %s", path)
     r = _client().post(path, json=body, params=params)
     r.raise_for_status()
@@ -94,7 +102,7 @@ def _build_filter(stream_ids: list[str]) -> dict | None:
 
 
 def _sync_search(body: dict, timeout_ms: int) -> dict:
-    return _post("/views/search/sync", body, params={"timeout": timeout_ms})
+    return _post("/views/search/sync", body=body, params={"timeout": timeout_ms})
 
 
 # ── Search (legacy — Graylog 4.x / 5.x) ──────────────────────────────────
@@ -630,7 +638,7 @@ def search_events(
     try:
         return _post(
             "/events/search",
-            {
+            body={
                 "query": query,
                 "timerange": {"type": "relative", "range": timerange_from},
                 "page": page,

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -1,11 +1,12 @@
 """Graylog MCP Server.
 
-Wraps the Graylog REST API and exposes search, streams, and alert endpoints
-as MCP tools for SOC workflows.
+Wraps the Graylog REST API and exposes search, streams, alerts, aggregations,
+pipelines, and dashboards as MCP tools for SOC workflows.
 """
 
 import logging
 import os
+import uuid
 from pathlib import Path
 
 import httpx
@@ -79,7 +80,28 @@ def _err(e: Exception) -> dict:
     return {"error": type(e).__name__, "detail": str(e)}
 
 
-# ── Search ─────────────────────────────────────────────────────────────────
+def _build_timerange(range_seconds: int | None, from_time: str, to_time: str) -> dict:
+    if from_time and to_time:
+        return {"type": "absolute", "from": from_time, "to": to_time}
+    return {"type": "relative", "range": range_seconds or 86400}
+
+
+def _build_filter(stream_ids: list[str]) -> dict | None:
+    filters = [{"type": "stream", "id": sid} for sid in stream_ids if sid]
+    if not filters:
+        return None
+    return {"type": "or", "filters": filters}
+
+
+def _parse_stream_ids(stream_ids: str) -> list[str]:
+    return [s.strip() for s in stream_ids.split(",") if s.strip()]
+
+
+def _sync_search(body: dict, timeout_ms: int) -> dict:
+    return _post("/views/search/sync", body, params={"timeout": timeout_ms})
+
+
+# ── Search (legacy — Graylog 4.x / 5.x) ──────────────────────────────────
 
 
 @mcp.tool()
@@ -182,6 +204,326 @@ def get_message(message_id: str, index: str) -> dict:
         return _err(e)
 
 
+# ── Search (Graylog 6.x — views/search/sync) ──────────────────────────────
+
+
+@mcp.tool()
+def search_sync(
+    query: str,
+    range_seconds: int = 86400,
+    from_time: str = "",
+    to_time: str = "",
+    limit: int = 50,
+    fields: str = "",
+    stream_ids: str = "",
+    sort_field: str = "timestamp",
+    sort_order: str = "DESC",
+    timeout_ms: int = 15000,
+) -> dict:
+    """Search Graylog 6.x messages using the views/search/sync API.
+
+    Use this instead of search_relative or search_absolute on Graylog 6.x.
+    The legacy /search/universal/* endpoints return no results on Graylog 6.x.
+
+    Args:
+        query: Lucene query string (e.g. 'srcip:"1.2.3.4"', 'alert_severity:1')
+        range_seconds: Relative time window in seconds (default 86400 = 24h).
+                       Ignored when from_time and to_time are both set.
+        from_time: Absolute start time ISO 8601 (e.g. 2025-04-01T00:00:00.000Z).
+                   Provide together with to_time to use an absolute range.
+        to_time: Absolute end time ISO 8601.
+        limit: Maximum number of messages to return (default 50)
+        fields: Comma-separated field names to include in each message.
+                Empty string returns all stored fields.
+        stream_ids: Comma-separated stream IDs to scope the search.
+                    Empty string searches across all streams.
+        sort_field: Field to sort by (default: timestamp)
+        sort_order: ASC or DESC (default: DESC)
+        timeout_ms: Server-side query timeout in milliseconds (default 15000)
+    """
+    try:
+        sid_list = _parse_stream_ids(stream_ids)
+        fields_list = [f.strip() for f in fields.split(",") if f.strip()]
+        search_type: dict = {
+            "id": "msgs",
+            "type": "messages",
+            "limit": limit,
+            "offset": 0,
+            "sort": [{"field": sort_field, "order": sort_order}],
+        }
+        if fields_list:
+            search_type["fields"] = fields_list
+
+        query_obj: dict = {
+            "id": str(uuid.uuid4()),
+            "query": {"type": "elasticsearch", "query_string": query},
+            "timerange": _build_timerange(range_seconds, from_time, to_time),
+            "search_types": [search_type],
+        }
+        f = _build_filter(sid_list)
+        if f:
+            query_obj["filter"] = f
+
+        raw = _sync_search({"queries": [query_obj]}, timeout_ms)
+        qid = query_obj["id"]
+        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("msgs", {})
+        messages = [m.get("message", m) for m in st.get("messages", [])]
+        return {
+            "total": st.get("total_results", 0),
+            "messages": messages,
+            "query": query,
+        }
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def aggregate_terms(
+    field: str,
+    query: str = "*",
+    range_seconds: int = 86400,
+    from_time: str = "",
+    to_time: str = "",
+    size: int = 20,
+    stream_ids: str = "",
+    timeout_ms: int = 15000,
+) -> dict:
+    """Get top-N values for a field using the Graylog 6.x views/search/sync API.
+
+    Use this instead of search_terms on Graylog 6.x.
+
+    Args:
+        field: Field name to aggregate (e.g. "dstip", "alert_signature", "srcuser")
+        query: Lucene filter query (default: all messages)
+        range_seconds: Relative time window in seconds (default 86400 = 24h)
+        from_time: Absolute start time ISO 8601. Pair with to_time for absolute range.
+        to_time: Absolute end time ISO 8601.
+        size: Number of top values to return (default 20)
+        stream_ids: Comma-separated stream IDs. Empty = all streams.
+        timeout_ms: Server-side timeout in milliseconds (default 15000)
+    """
+    try:
+        sid_list = _parse_stream_ids(stream_ids)
+        search_type = {
+            "id": "terms_0",
+            "type": "pivot",
+            "row_groups": [{"type": "values", "field": field, "limit": size}],
+            "column_groups": [],
+            "series": [{"type": "count", "id": "count", "field": None}],
+            "rollup": False,
+        }
+        query_obj: dict = {
+            "id": str(uuid.uuid4()),
+            "query": {"type": "elasticsearch", "query_string": query},
+            "timerange": _build_timerange(range_seconds, from_time, to_time),
+            "search_types": [search_type],
+        }
+        f = _build_filter(sid_list)
+        if f:
+            query_obj["filter"] = f
+
+        raw = _sync_search({"queries": [query_obj]}, timeout_ms)
+        qid = query_obj["id"]
+        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("terms_0", {})
+        terms = [
+            {"value": row["key"][0], "count": row["values"][0].get("value", 0)}
+            for row in st.get("rows", [])
+            if row.get("key")
+        ]
+        return {"field": field, "terms": terms}
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def aggregate_histogram(
+    query: str = "*",
+    range_seconds: int = 86400,
+    from_time: str = "",
+    to_time: str = "",
+    interval: str = "auto",
+    stream_ids: str = "",
+    timeout_ms: int = 15000,
+) -> dict:
+    """Get message count bucketed over time using the Graylog 6.x views/search/sync API.
+
+    Use this instead of search_histogram on Graylog 6.x.
+
+    Args:
+        query: Lucene filter query (default: all messages)
+        range_seconds: Relative time window in seconds (default 86400 = 24h)
+        from_time: Absolute start time ISO 8601. Pair with to_time for absolute range.
+        to_time: Absolute end time ISO 8601.
+        interval: Bucket size — "auto", "minute", "hour", "day", "week", "month".
+                  "auto" lets Graylog choose based on the time range.
+        stream_ids: Comma-separated stream IDs. Empty = all streams.
+        timeout_ms: Server-side timeout in milliseconds (default 15000)
+    """
+    _UNIT_MAP = {
+        "minute": "MINUTES", "minutes": "MINUTES",
+        "hour": "HOURS", "hours": "HOURS",
+        "day": "DAYS", "days": "DAYS",
+        "week": "WEEKS", "weeks": "WEEKS",
+        "month": "MONTHS", "months": "MONTHS",
+    }
+    try:
+        sid_list = _parse_stream_ids(stream_ids)
+        if interval == "auto":
+            row_group = {
+                "type": "time",
+                "field": "timestamp",
+                "interval": {"type": "auto", "scaling": 1.0},
+            }
+        else:
+            unit = _UNIT_MAP.get(interval.lower(), "HOURS")
+            row_group = {
+                "type": "time",
+                "field": "timestamp",
+                "interval": {"type": "timeunit", "value": 1, "unit": unit},
+            }
+        search_type = {
+            "id": "hist_0",
+            "type": "pivot",
+            "row_groups": [row_group],
+            "column_groups": [],
+            "series": [{"type": "count", "id": "count", "field": None}],
+            "rollup": False,
+        }
+        query_obj: dict = {
+            "id": str(uuid.uuid4()),
+            "query": {"type": "elasticsearch", "query_string": query},
+            "timerange": _build_timerange(range_seconds, from_time, to_time),
+            "search_types": [search_type],
+        }
+        f = _build_filter(sid_list)
+        if f:
+            query_obj["filter"] = f
+
+        raw = _sync_search({"queries": [query_obj]}, timeout_ms)
+        qid = query_obj["id"]
+        st = raw.get("results", {}).get(qid, {}).get("search_types", {}).get("hist_0", {})
+        buckets = [
+            {"timestamp": row["key"][0], "count": row["values"][0].get("value", 0)}
+            for row in st.get("rows", [])
+            if row.get("key")
+        ]
+        return {"interval": interval, "buckets": buckets}
+    except Exception as e:
+        return _err(e)
+
+
+# ── Aggregations (legacy — Graylog 4.x / 5.x) ────────────────────────────
+
+
+@mcp.tool()
+def search_terms(
+    field: str,
+    query: str = "*",
+    range_seconds: int = 3600,
+    size: int = 10,
+    stream_id: str = "",
+) -> dict:
+    """Get top-N values for a field (term frequency / cardinality).
+
+    Useful for finding top source IPs, usernames, error codes, etc.
+
+    Args:
+        field: Field name to aggregate (e.g. "source", "gl2_source_input")
+        query: Filter query in Lucene syntax (default: all messages)
+        range_seconds: How far back to search in seconds (default: 3600 = 1 hour)
+        size: Number of top values to return (default: 10)
+        stream_id: Limit to a specific stream ID (optional)
+    """
+    params: dict = {"field": field, "query": query, "range": range_seconds, "size": size}
+    if stream_id:
+        params["filter"] = f"streams:{stream_id}"
+    try:
+        return _get("/search/universal/relative/terms", params)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def search_stats(
+    field: str,
+    query: str = "*",
+    range_seconds: int = 3600,
+    stream_id: str = "",
+) -> dict:
+    """Get statistical summary for a numeric field (min, max, mean, sum, stddev).
+
+    Args:
+        field: Numeric field name (e.g. "http_response_code", "took_ms")
+        query: Filter query in Lucene syntax (default: all messages)
+        range_seconds: How far back to search in seconds (default: 3600 = 1 hour)
+        stream_id: Limit to a specific stream ID (optional)
+    """
+    params: dict = {"field": field, "query": query, "range": range_seconds}
+    if stream_id:
+        params["filter"] = f"streams:{stream_id}"
+    try:
+        return _get("/search/universal/relative/stats", params)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def search_histogram(
+    query: str = "*",
+    range_seconds: int = 3600,
+    interval: str = "hour",
+    stream_id: str = "",
+) -> dict:
+    """Get message count over time (time-bucketed histogram).
+
+    Useful for spotting spikes or drops in log volume.
+
+    Args:
+        query: Filter query in Lucene syntax (default: all messages)
+        range_seconds: How far back to search in seconds (default: 3600 = 1 hour)
+        interval: Bucket size — minute, hour, day, week, month, quarter, year
+        stream_id: Limit to a specific stream ID (optional)
+    """
+    params: dict = {"query": query, "range": range_seconds, "interval": interval}
+    if stream_id:
+        params["filter"] = f"streams:{stream_id}"
+    try:
+        return _get("/search/universal/relative/histogram", params)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def search_field_histogram(
+    field: str,
+    query: str = "*",
+    range_seconds: int = 3600,
+    interval: str = "hour",
+    stream_id: str = "",
+) -> dict:
+    """Get a numeric field's value distribution over time.
+
+    Args:
+        field: Numeric field name (e.g. "took_ms", "bytes")
+        query: Filter query in Lucene syntax (default: all messages)
+        range_seconds: How far back to search in seconds (default: 3600 = 1 hour)
+        interval: Bucket size — minute, hour, day, week, month, quarter, year
+        stream_id: Limit to a specific stream ID (optional)
+    """
+    params: dict = {
+        "field": field,
+        "query": query,
+        "range": range_seconds,
+        "interval": interval,
+    }
+    if stream_id:
+        params["filter"] = f"streams:{stream_id}"
+    try:
+        return _get("/search/universal/relative/fieldhistogram", params)
+    except Exception as e:
+        return _err(e)
+
+
 # ── Streams ────────────────────────────────────────────────────────────────
 
 
@@ -203,6 +545,37 @@ def get_stream(stream_id: str) -> dict:
     """
     try:
         return _get(f"/streams/{stream_id}")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def find_stream(name: str) -> dict:
+    """Find streams whose title matches a name (case-insensitive substring match).
+
+    Call this at the start of an investigation to resolve a human-readable stream
+    name (e.g. "firewall", "proxy", "edr", "windows") into its Graylog stream ID.
+    Pass the returned id as stream_id to any search tool to scope queries to that
+    stream only instead of searching across all streams.
+
+    Args:
+        name: Partial or full stream title to search for (e.g. "firewall", "proxy", "edr")
+    """
+    try:
+        result = _get("/streams")
+        streams = result.get("streams", [])
+        name_lower = name.lower()
+        matches = [
+            {
+                "id": s.get("id"),
+                "title": s.get("title"),
+                "description": s.get("description", ""),
+                "disabled": s.get("disabled", False),
+            }
+            for s in streams
+            if name_lower in s.get("title", "").lower()
+        ]
+        return {"query": name, "matches": matches, "total": len(matches)}
     except Exception as e:
         return _err(e)
 
@@ -244,6 +617,128 @@ def list_event_definitions() -> dict:
     """List all event/alert definitions configured in Graylog."""
     try:
         return _get("/events/definitions")
+    except Exception as e:
+        return _err(e)
+
+
+# ── Pipelines ──────────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def list_pipelines() -> dict:
+    """List all processing pipelines configured in Graylog."""
+    try:
+        return _get("/system/pipelines/pipeline")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def get_pipeline(pipeline_id: str) -> dict:
+    """Get details for a specific processing pipeline, including its stages and rules.
+
+    Args:
+        pipeline_id: The pipeline ID
+    """
+    try:
+        return _get(f"/system/pipelines/pipeline/{pipeline_id}")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def list_pipeline_rules() -> dict:
+    """List all pipeline rules configured in Graylog."""
+    try:
+        return _get("/system/pipelines/rule")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def get_pipeline_rule(rule_id: str) -> dict:
+    """Get a specific pipeline rule, including its source code.
+
+    Args:
+        rule_id: The pipeline rule ID
+    """
+    try:
+        return _get(f"/system/pipelines/rule/{rule_id}")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def list_pipeline_connections() -> dict:
+    """List which streams are connected to which processing pipelines."""
+    try:
+        return _get("/system/pipelines/connections")
+    except Exception as e:
+        return _err(e)
+
+
+# ── Dashboards & Saved Searches ────────────────────────────────────────────
+
+
+@mcp.tool()
+def list_dashboards() -> dict:
+    """List all dashboards in Graylog."""
+    try:
+        return _get("/dashboards")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def get_dashboard(dashboard_id: str) -> dict:
+    """Get a specific dashboard with its widget list.
+
+    Args:
+        dashboard_id: The dashboard ID
+    """
+    try:
+        return _get(f"/dashboards/{dashboard_id}")
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def list_saved_searches() -> dict:
+    """List all saved searches.
+
+    Tries the Graylog 5.x/6.x Views API first, falls back to the 4.x saved search API.
+    """
+    try:
+        return _get("/search/views", {"type": "SEARCH"})
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            try:
+                return _get("/search/saved")
+            except Exception as e2:
+                return _err(e2)
+        return _err(e)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def get_saved_search(search_id: str) -> dict:
+    """Get a specific saved search by ID.
+
+    Tries the Graylog 5.x/6.x Views API first, falls back to the 4.x saved search API.
+
+    Args:
+        search_id: The saved search or view ID
+    """
+    try:
+        return _get(f"/search/views/{search_id}")
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            try:
+                return _get(f"/search/saved/{search_id}")
+            except Exception as e2:
+                return _err(e2)
+        return _err(e)
     except Exception as e:
         return _err(e)
 

--- a/iris-mcp/requirements.txt
+++ b/iris-mcp/requirements.txt
@@ -1,2 +1,4 @@
 mcp[cli]>=1.0.0
 httpx>=0.27.0
+tenacity>=8.0.0
+python-dotenv>=1.0.0

--- a/iris-mcp/server.py
+++ b/iris-mcp/server.py
@@ -1,29 +1,99 @@
 """DFIR-IRIS MCP Server.
 
-Wraps the DFIR-IRIS REST API and exposes case management endpoints as MCP tools.
+Wraps the DFIR-IRIS REST API and exposes case management, IOC, asset, timeline,
+notes, and investigation tools as MCP tools for SOC workflows.
 """
 
+import logging
 import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import httpx
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "WARNING"))
+logger = logging.getLogger("iris-mcp")
 
 mcp = FastMCP("dfir-iris")
 
 IRIS_URL = os.environ.get("IRIS_URL", "https://localhost:8443")
 IRIS_API_KEY = os.environ.get("IRIS_API_KEY", "")
+IRIS_VERIFY_SSL = os.getenv("IRIS_VERIFY_SSL", "false").lower() != "false"
+
+if not IRIS_API_KEY:
+    logger.warning("IRIS_API_KEY is not set — all API calls will fail with 401")
+
+_http: httpx.Client | None = None
 
 
 def _client() -> httpx.Client:
-    return httpx.Client(
-        base_url=IRIS_URL,
-        headers={
-            "Authorization": f"Bearer {IRIS_API_KEY}",
-            "User-Agent": "iris-mcp/1.0",
-        },
-        verify=False,
-        timeout=30,
-    )
+    global _http
+    if _http is None:
+        _http = httpx.Client(
+            base_url=IRIS_URL,
+            headers={
+                "Authorization": f"Bearer {IRIS_API_KEY}",
+                "User-Agent": "iris-mcp/1.0",
+                "Content-Type": "application/json",
+            },
+            verify=IRIS_VERIFY_SSL,
+            timeout=30,
+        )
+    return _http
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _get(path: str, params: dict | None = None) -> dict:
+    logger.debug("GET %s params=%s", path, params)
+    r = _client().get(path, params=params)
+    r.raise_for_status()
+    return r.json()
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(httpx.TransportError),
+    reraise=True,
+)
+def _post(path: str, params: dict | None = None, body: dict | None = None) -> dict:
+    logger.debug("POST %s", path)
+    r = _client().post(path, params=params, json=body or {})
+    r.raise_for_status()
+    return r.json()
+
+
+def _err(e: Exception) -> dict:
+    if isinstance(e, httpx.HTTPStatusError):
+        return {
+            "error": f"HTTP {e.response.status_code}",
+            "url": str(e.request.url),
+            "detail": e.response.text[:500],
+        }
+    return {"error": type(e).__name__, "detail": str(e)}
+
+
+def _parse_since(since: str) -> datetime | None:
+    """Parse a human time delta string into a UTC cutoff datetime."""
+    if not since:
+        return None
+    since = since.strip().lower()
+    units = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
+    if since[-1] in units and since[:-1].isdigit():
+        return datetime.now(timezone.utc) - timedelta(**{units[since[-1]]: int(since[:-1])})
+    try:
+        return datetime.fromisoformat(since).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
 
 
 # ── Cases ──────────────────────────────────────────────────────────────────
@@ -32,10 +102,10 @@ def _client() -> httpx.Client:
 @mcp.tool()
 def list_cases() -> dict:
     """List all cases in DFIR-IRIS."""
-    with _client() as c:
-        r = c.get("/manage/cases/list")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/manage/cases/list")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -45,10 +115,10 @@ def get_case(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get(f"/manage/cases/{case_id}")
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get(f"/manage/cases/{case_id}")
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -66,18 +136,18 @@ def create_case(
         case_customer: Customer ID (default: 1)
         case_soc_id: SOC ticket ID (optional)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/manage/cases/add",
-            json={
+            body={
                 "case_name": case_name,
                 "case_description": case_description,
                 "case_customer": case_customer,
                 "case_soc_id": case_soc_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── IOCs ───────────────────────────────────────────────────────────────────
@@ -85,15 +155,15 @@ def create_case(
 
 @mcp.tool()
 def list_iocs(case_id: int) -> dict:
-    """List all IOCs (Indicators of Compromise) for a case.
+    """List all IOCs for a case.
 
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/ioc/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/ioc/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -107,25 +177,25 @@ def add_ioc(
     """Add an IOC to a case.
 
     Args:
-        case_id: The case ID to add the IOC to
+        case_id: The case ID
         ioc_value: The IOC value (IP, hash, domain, etc.)
-        ioc_type_id: Type of IOC (1=hash, 2=IP, 3=domain, etc.)
+        ioc_type_id: IOC type (1=hash, 2=IP, 3=domain, 4=URL, 5=email, 6=filename, 7=hostname)
         ioc_description: Description of the IOC
         ioc_tlp_id: TLP level (1=red, 2=amber, 3=green, 4=white)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/ioc/add",
             params={"cid": case_id},
-            json={
+            body={
                 "ioc_value": ioc_value,
                 "ioc_type_id": ioc_type_id,
                 "ioc_description": ioc_description,
                 "ioc_tlp_id": ioc_tlp_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Assets ─────────────────────────────────────────────────────────────────
@@ -138,10 +208,10 @@ def list_assets(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/assets/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/assets/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -157,23 +227,23 @@ def add_asset(
     Args:
         case_id: The case ID
         asset_name: Name or hostname of the asset
-        asset_type_id: Asset type (1=account, 2=firewall, 3=linux-server, 4=linux-workstation, 5=mac, 9=windows-server, 10=windows-workstation, etc.)
+        asset_type_id: Asset type (1=account, 2=firewall, 3=linux-server, 4=linux-workstation, 5=mac, 9=windows-server, 10=windows-workstation)
         asset_description: Description of the asset
         asset_compromise_status_id: Compromise status (0=unknown, 1=compromised, 2=not compromised, 3=remediated)
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/assets/add",
             params={"cid": case_id},
-            json={
+            body={
                 "asset_name": asset_name,
                 "asset_type_id": asset_type_id,
                 "asset_description": asset_description,
                 "asset_compromise_status_id": asset_compromise_status_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Timeline ───────────────────────────────────────────────────────────────
@@ -186,10 +256,10 @@ def list_timeline(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/timeline/events/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/timeline/events/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -205,23 +275,23 @@ def add_timeline_event(
     Args:
         case_id: The case ID
         event_title: Title of the event
-        event_date: Date/time of the event (ISO format)
-        event_content: Detailed description
+        event_date: Date/time of the event (ISO 8601 format, e.g. 2024-01-15T10:00:00)
+        event_content: Detailed description (Markdown supported)
         event_category_id: Category ID for the event
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/timeline/events/add",
             params={"cid": case_id},
-            json={
+            body={
                 "event_title": event_title,
                 "event_date": event_date,
                 "event_content": event_content,
                 "event_category_id": event_category_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 # ── Notes ──────────────────────────────────────────────────────────────────
@@ -234,10 +304,10 @@ def list_notes_groups(case_id: int) -> dict:
     Args:
         case_id: The numeric case ID
     """
-    with _client() as c:
-        r = c.get("/case/notes/groups/list", params={"cid": case_id})
-        r.raise_for_status()
-        return r.json()
+    try:
+        return _get("/case/notes/groups/list", {"cid": case_id})
+    except Exception as e:
+        return _err(e)
 
 
 @mcp.tool()
@@ -255,18 +325,18 @@ def add_note(
         note_content: Markdown content of the note
         group_id: Note group ID to add the note to
     """
-    with _client() as c:
-        r = c.post(
+    try:
+        return _post(
             "/case/notes/add",
             params={"cid": case_id},
-            json={
+            body={
                 "note_title": note_title,
                 "note_content": note_content,
                 "group_id": group_id,
             },
         )
-        r.raise_for_status()
-        return r.json()
+    except Exception as e:
+        return _err(e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **`_post` keyword convention**: `body` is now keyword-only (`def _post(path, *, body, params)`). All call sites updated to `body=...`. Removes the ambiguity of a positional second argument on an internal helper.
- **Configurable dotenv path**: `load_dotenv` now reads the path from `DOTENV_PATH` env var, falling back to `../../.env` relative to `server.py` (the project root for local dev). Documented in README. In production the env var is never set so the file is simply not found — no behavior change.
- **Stale connection reset**: Added `before_sleep=_reconnect` to both `@retry` decorators. On each transport-error retry, `_http` is set to `None` so `_client()` opens a fresh `httpx.Client` instead of reusing a connection that may have been dropped by the server or a firewall.

> **Stacked on:** PR #9 (`pr/7-native-remove`)

## Test plan

- [ ] Calling any search tool while Graylog is briefly unreachable retries and succeeds after reconnect
- [ ] `DOTENV_PATH=/tmp/test.env` is respected at startup
- [ ] All existing tools continue to work (no regression from keyword-only `body`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)