### PR TITLE
Add importable Docker MCP catalog (graylog, iris, swiss)

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -1,0 +1,37 @@
+name: Publish MCP Catalog
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'catalog/**'
+      - 'publish-catalog'
+      - '.github/workflows/catalog.yml'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install docker mcp plugin
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          version="$(curl -fsSL https://api.github.com/repos/docker/mcp-gateway/releases | jq -r '.[0].tag_name')"
+          curl -fsSL "https://github.com/docker/mcp-gateway/releases/download/${version}/docker-mcp-linux-amd64.tar.gz" \
+            | tar -xz -C ~/.docker/cli-plugins docker-mcp
+          chmod +x ~/.docker/cli-plugins/docker-mcp
+          docker mcp version
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push catalog
+        run: ./publish-catalog ghcr.io/${{ github.repository_owner }}/bluearmory:latest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,46 @@
 
 A collection of MCP servers and skills for blue team / SOC workflows.
 
+## Quick start: import the Docker MCP catalog
+
+bluearmory ships as a Docker MCP **catalog** — one OCI reference gets you the
+first-party servers pre-configured (name, secrets, config prompts, tool list).
+
+**Docker Desktop** → MCP Toolkit → Catalogs → **Import catalog**, then paste:
+
+```
+ghcr.io/gabrielbelli/bluearmory:latest
+```
+
+**CLI:**
+
+```bash
+docker mcp catalog pull ghcr.io/gabrielbelli/bluearmory:latest
+```
+
+Then enable the servers you want and set their secrets (e.g. `graylog.api_token`)
+in the MCP Toolkit UI or with `docker mcp secret set`.
+
+> The catalog bundles the container-based servers ([`graylog`](graylog-mcp/),
+> [`iris`](#mcp-iris), and [`swiss`](#swiss)). Kali is listed below as a manual entry
+> only because it uses an SSH transport rather than a container image, which the
+> catalog format doesn't express.
+
+### Publishing the catalog (maintainers)
+
+Server definitions live in [`catalog/`](catalog/) (one YAML per server, following the
+[MCP server entry spec](https://github.com/docker/mcp-gateway/blob/main/docs/server-entry-spec.md)).
+Build and push with:
+
+```bash
+./publish-catalog                        # → ghcr.io/gabrielbelli/bluearmory:latest
+./publish-catalog ghcr.io/you/name:tag   # custom reference
+```
+
+CI ([`.github/workflows/catalog.yml`](.github/workflows/catalog.yml)) re-publishes
+automatically on any change under `catalog/`. To add a server, drop a new
+`catalog/<name>.yaml` in place — no other edits needed.
+
 ## MCP Servers
 
 Pre-built multi-arch images (amd64 + arm64) are published to GHCR.
@@ -48,7 +88,7 @@ Aggregated threat intelligence — fan-out queries across VirusTotal, AbuseIPDB,
     "swiss": {
       "command": "docker",
       "args": [
-        "run", "-i", "--rm", "--network", "host",
+        "run", "-i", "--rm",
         "-v", "${HOME}/.config/swiss/config.json:/config/swiss.json:ro",
         "-e", "SWISS_CONFIG_PATH=/config/swiss.json",
         "-e", "SWISS_VIRUSTOTAL_API_KEY",
@@ -61,6 +101,15 @@ Aggregated threat intelligence — fan-out queries across VirusTotal, AbuseIPDB,
   }
 }
 ```
+
+> **Networking:** bridge networking (the default above) reaches public threat-intel
+> APIs and any self-hosted back-end (MISP, Graylog, DFIR-IRIS, Wazuh) that lives on
+> the web, another LAN host, or a VPN-reachable host — the container inherits the
+> host's routes. Add `--network host` **only** if a back-end is bound to `127.0.0.1`
+> on the same machine running the container; otherwise `--add-host name:ip` or a real
+> DNS name is enough. Swiss is also in the [importable catalog](#quick-start-import-the-docker-mcp-catalog),
+> which wires the common public API keys; use this manual entry for the full env
+> surface (abuse.ch, IBM X-Force, Censys, and the self-hosted MISP/Graylog/IRIS/Wazuh back-ends).
 
 ### Kali MCP
 

--- a/catalog/graylog.yaml
+++ b/catalog/graylog.yaml
@@ -1,0 +1,43 @@
+name: graylog
+type: server
+title: Graylog
+description: Graylog SIEM log search, streams, and alert/event queries for SOC workflows.
+image: ghcr.io/gabrielbelli/graylog-mcp:latest
+icon: https://avatars.githubusercontent.com/u/6321561
+config:
+  - name: graylog
+    description: Connection to your Graylog instance
+    type: object
+    properties:
+      url:
+        type: string
+        description: Base URL of the Graylog server (e.g. https://graylog.example.com:9000)
+    required:
+      - url
+env:
+  - name: GRAYLOG_URL
+    value: "{{graylog.url}}"
+secrets:
+  - name: graylog.api_token
+    env: GRAYLOG_API_TOKEN
+    example: 1a2b3c4d5e6f...
+tools:
+  - name: search_relative
+  - name: search_absolute
+  - name: search_keyword
+  - name: get_message
+  - name: list_streams
+  - name: get_stream
+  - name: search_events
+  - name: list_event_definitions
+  - name: system_overview
+  - name: list_inputs
+metadata:
+  category: monitoring
+  tags:
+    - siem
+    - logs
+    - blue-team
+    - soc
+  license: MIT
+  owner: gabrielbelli

--- a/catalog/iris.yaml
+++ b/catalog/iris.yaml
@@ -1,0 +1,32 @@
+name: iris
+type: server
+title: DFIR-IRIS
+description: Read-only access to DFIR-IRIS incident-response case management — cases, alerts, IOCs, notes, and timeline.
+image: ghcr.io/bunnyiesart/mcp-iris:latest
+icon: https://avatars.githubusercontent.com/u/95911680
+config:
+  - name: iris
+    description: Connection to your DFIR-IRIS instance
+    type: object
+    properties:
+      url:
+        type: string
+        description: Base URL of the DFIR-IRIS server (e.g. https://iris.example.com)
+    required:
+      - url
+env:
+  - name: IRIS_URL
+    value: "{{iris.url}}"
+secrets:
+  - name: iris.api_key
+    env: IRIS_API_KEY
+    example: your_iris_api_key
+metadata:
+  category: security
+  tags:
+    - dfir
+    - incident-response
+    - case-management
+    - blue-team
+  license: MIT
+  owner: bunnyiesart

--- a/catalog/swiss.yaml
+++ b/catalog/swiss.yaml
@@ -1,0 +1,41 @@
+name: swiss
+type: server
+title: Swiss
+description: Aggregated threat intelligence — fan-out lookups across VirusTotal, AbuseIPDB, GreyNoise, Shodan, urlscan, AlienVault OTX, and 15+ other sources in one call. Public sources run keyless; add keys to unlock more.
+image: ghcr.io/bunnyiesart/swiss:latest
+secrets:
+  - name: swiss.virustotal_api_key
+    env: SWISS_VIRUSTOTAL_API_KEY
+    example: your_virustotal_key
+  - name: swiss.abuseipdb_api_key
+    env: SWISS_ABUSEIPDB_API_KEY
+    example: your_abuseipdb_key
+  - name: swiss.alienvault_api_key
+    env: SWISS_ALIENVAULT_API_KEY
+    example: your_otx_key
+  - name: swiss.urlscan_api_key
+    env: SWISS_URLSCAN_API_KEY
+    example: your_urlscan_key
+  - name: swiss.shodan_api_key
+    env: SWISS_SHODAN_API_KEY
+    example: your_shodan_key
+  - name: swiss.greynoise_api_key
+    env: SWISS_GREYNOISE_API_KEY
+    example: your_greynoise_key
+tools:
+  - name: lookup_ip
+  - name: lookup_domain
+  - name: lookup_hash
+  - name: lookup_url
+  - name: check_exposure
+  - name: lookup_eventid
+metadata:
+  category: security
+  tags:
+    - threat-intel
+    - ioc
+    - enrichment
+    - blue-team
+    - soc
+  license: MIT
+  owner: bunnyiesart

--- a/publish-catalog
+++ b/publish-catalog
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build the bluearmory MCP catalog from catalog/*.yaml and push it to an OCI registry.
+# Users then import it in Docker Desktop → MCP Toolkit → Catalogs → Import catalog,
+# or with:  docker mcp catalog pull <oci-ref>
+#
+# Usage:
+#   ./publish-catalog                       # push ghcr.io/gabrielbelli/bluearmory:latest
+#   ./publish-catalog ghcr.io/you/name:tag  # push a custom reference
+#   OCI_REF=... ./publish-catalog           # same, via env
+set -euo pipefail
+
+OCI_REF="${1:-${OCI_REF:-ghcr.io/gabrielbelli/bluearmory:latest}}"
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+CATALOG_SRC="$REPO_DIR/catalog"
+RESOLVE_DIR="$HOME/.docker/mcp/catalogs"   # where --server file:// is resolved
+
+command -v docker >/dev/null || { echo "docker not found" >&2; exit 1; }
+docker mcp version >/dev/null 2>&1 || {
+  echo "The 'docker mcp' plugin is required (Docker Desktop MCP Toolkit, or the docker/mcp-gateway plugin)." >&2
+  exit 1
+}
+
+mkdir -p "$RESOLVE_DIR"
+
+# Copy every server entry into the resolve dir and collect --server flags.
+server_args=()
+copied=()
+for f in "$CATALOG_SRC"/*.yaml; do
+  base="$(basename "$f")"
+  cp "$f" "$RESOLVE_DIR/$base"
+  copied+=("$RESOLVE_DIR/$base")
+  server_args+=(--server "file://$base")
+done
+trap 'rm -f "${copied[@]}"' EXIT
+
+echo ">> Building catalog $OCI_REF"
+docker mcp catalog rm "$OCI_REF" >/dev/null 2>&1 || true
+docker mcp catalog create "$OCI_REF" \
+  --title "bluearmory — blue team / SOC MCP servers" \
+  "${server_args[@]}"
+
+echo ">> Pushing $OCI_REF"
+docker mcp catalog push "$OCI_REF"
+
+echo ">> Done. Import it with:"
+echo "     docker mcp catalog pull $OCI_REF"
+echo "   or in Docker Desktop: MCP Toolkit → Catalogs → Import catalog → $OCI_REF"


### PR DESCRIPTION
Ships bluearmory as an OCI catalog importable via Docker Desktop (MCP Toolkit → Catalogs → Import catalog) or `docker mcp catalog pull ghcr.io/gabrielbelli/bluearmory:latest`.

- `catalog/` — server entries for graylog, iris, swiss (tags float on `:latest`)
- `publish-catalog` — build + push the catalog to GHCR
- `.github/workflows/catalog.yml` — auto-publishes on `catalog/**` changes
- README import quick-start; removed unnecessary `--network host` from the swiss example

Merging this triggers the publish workflow.