### PR TITLE
Use official Graylog logo for graylog catalog icon

### DIFF
--- a/catalog/graylog.yaml
+++ b/catalog/graylog.yaml
@@ -3,7 +3,7 @@ type: server
 title: Graylog
 description: Graylog SIEM log search, streams, and alert/event queries for SOC workflows.
 image: ghcr.io/gabrielbelli/graylog-mcp:latest
-icon: https://avatars.githubusercontent.com/u/6321561
+icon: https://avatars.githubusercontent.com/u/474892
 config:
   - name: graylog
     description: Connection to your Graylog instance


### PR DESCRIPTION
Swaps the placeholder icon on the graylog catalog entry for the official Graylog GitHub org avatar. Republishes the catalog via CI on merge.