### PR TITLE
Fix broken Overview tab: raw-markdown readme URLs

### DIFF
--- a/catalog/graylog.yaml
+++ b/catalog/graylog.yaml
@@ -4,6 +4,7 @@ title: Graylog
 description: Graylog SIEM log search, streams, and alert/event queries for SOC workflows.
 image: ghcr.io/gabrielbelli/graylog-mcp:latest
 icon: https://avatars.githubusercontent.com/u/474892
+readme: https://raw.githubusercontent.com/gabrielbelli/bluearmory/master/graylog-mcp/README.md
 config:
   - name: graylog
     description: Connection to your Graylog instance

--- a/catalog/iris.yaml
+++ b/catalog/iris.yaml
@@ -4,6 +4,7 @@ title: DFIR-IRIS
 description: Read-only access to DFIR-IRIS incident-response case management — cases, alerts, IOCs, notes, and timeline.
 image: ghcr.io/bunnyiesart/mcp-iris:latest
 icon: https://avatars.githubusercontent.com/u/95911680
+readme: https://raw.githubusercontent.com/bunnyiesart/mcp-iris/main/ARCHITECTURE.md
 config:
   - name: iris
     description: Connection to your DFIR-IRIS instance

--- a/catalog/swiss.yaml
+++ b/catalog/swiss.yaml
@@ -3,7 +3,7 @@ type: server
 title: Swiss
 description: Aggregated threat intelligence — fan-out lookups across VirusTotal, AbuseIPDB, GreyNoise, Shodan, urlscan, AlienVault OTX, and 15+ other sources in one call. Public sources run keyless; add keys to unlock more. Secrets and self-hosted URLs are set here; for finer tuning (enable/disable sources, favourite a source to get its own tool, verify_ssl, custom blacklists) mount a config.json — see the readme.
 image: ghcr.io/bunnyiesart/swiss:latest
-readme: https://github.com/bunnyiesart/swiss/blob/main/docs/configuration.md
+readme: https://raw.githubusercontent.com/bunnyiesart/swiss/main/README.md
 secrets:
   # ── Free key, ~2 min ──────────────────────────────────────────────────────
   - name: swiss.virustotal_api_key


### PR DESCRIPTION
The swiss `readme` pointed at `github.com/.../blob/...` — a **text/html** page — so Docker's Overview tab dumped the raw HTML (`<link>`/`<style>`/`<script>`).

- **swiss**: readme → raw `README.md` (`text/plain` markdown), which also covers the config file.
- **graylog** + **iris**: added readmes (raw `graylog-mcp/README.md` and iris `ARCHITECTURE.md`) — they previously had none, so their Overview was empty.

Verified: builds clean, all three readmes are raw URLs. Merge republishes via CI.