### PR TITLE
Add opensearch server, list iris tools, prefix graylog tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then enable the servers you want and set their secrets (e.g. `graylog.api_token`
 in the MCP Toolkit UI or with `docker mcp secret set`.
 
 > The catalog bundles the container-based servers ([`graylog`](graylog-mcp/),
-> [`iris`](#mcp-iris), and [`swiss`](#swiss)). Kali is listed below as a manual entry
+> [`iris`](#mcp-iris), [`opensearch`](#mcp-opensearch), and [`swiss`](#swiss)). Kali is listed below as a manual entry
 > only because it uses an SSH transport rather than a container image, which the
 > catalog format doesn't express.
 
@@ -87,6 +87,30 @@ Read-only MCP server for [DFIR-IRIS](https://dfir-iris.org/) — incident respon
         "-e", "IRIS_URL",
         "-e", "IRIS_API_KEY",
         "ghcr.io/bunnyiesart/mcp-iris:latest"
+      ]
+    }
+  }
+}
+```
+
+### mcp-opensearch
+
+Read-only MCP server for [OpenSearch](https://opensearch.org/) / OpenSearch Dashboards — search, aggregate, and explore log data for SOC workflows. 17 tools spanning connectivity, discovery, search (incl. PPL), and aggregations, with hard result caps.
+
+- **Source:** [bunnyiesart/mcp-opensearch](https://github.com/bunnyiesart/mcp-opensearch)
+- **Image:** `ghcr.io/bunnyiesart/mcp-opensearch:latest`
+
+```json
+{
+  "mcpServers": {
+    "opensearch": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "OPENSEARCH_DASHBOARDS_URL",
+        "-e", "OPENSEARCH_USERNAME",
+        "-e", "OPENSEARCH_PASSWORD",
+        "ghcr.io/bunnyiesart/mcp-opensearch:latest"
       ]
     }
   }

--- a/catalog/graylog.yaml
+++ b/catalog/graylog.yaml
@@ -23,16 +23,16 @@ secrets:
     env: GRAYLOG_API_TOKEN
     example: 1a2b3c4d5e6f...
 tools:
-  - name: search_relative
-  - name: search_absolute
-  - name: search_keyword
-  - name: get_message
-  - name: list_streams
-  - name: get_stream
-  - name: search_events
-  - name: list_event_definitions
-  - name: system_overview
-  - name: list_inputs
+  - name: graylog_search_relative
+  - name: graylog_search_absolute
+  - name: graylog_search_keyword
+  - name: graylog_get_message
+  - name: graylog_list_streams
+  - name: graylog_get_stream
+  - name: graylog_search_events
+  - name: graylog_list_event_definitions
+  - name: graylog_system_overview
+  - name: graylog_list_inputs
 metadata:
   category: monitoring
   tags:

--- a/catalog/iris.yaml
+++ b/catalog/iris.yaml
@@ -22,6 +22,17 @@ secrets:
   - name: iris.api_key
     env: IRIS_API_KEY
     example: your_iris_api_key
+tools:
+  - name: list_cases
+  - name: list_untreated_cases
+  - name: get_case
+  - name: get_case_summary
+  - name: list_case_iocs
+  - name: list_case_assets
+  - name: list_case_tasks
+  - name: get_reference_data
+  - name: search_ioc_global
+  - name: find_related_cases
 metadata:
   category: security
   tags:

--- a/catalog/opensearch.yaml
+++ b/catalog/opensearch.yaml
@@ -1,0 +1,62 @@
+name: opensearch
+type: server
+title: OpenSearch
+description: Read-only search, aggregation, and exploration of OpenSearch / OpenSearch Dashboards log data for SOC workflows.
+image: ghcr.io/bunnyiesart/mcp-opensearch:latest
+icon: https://avatars.githubusercontent.com/u/80134844
+readme: https://raw.githubusercontent.com/bunnyiesart/mcp-opensearch/main/README.md
+config:
+  - name: opensearch
+    description: Connection to your OpenSearch / OpenSearch Dashboards instance
+    type: object
+    properties:
+      dashboards_url:
+        type: string
+        description: Base URL of OpenSearch Dashboards (e.g. https://opensearch.example.com)
+      url:
+        type: string
+        description: Direct OpenSearch REST API endpoint (fallback if Dashboards is unavailable)
+      username:
+        type: string
+        description: Basic auth username
+    required:
+      - dashboards_url
+      - username
+env:
+  - name: OPENSEARCH_DASHBOARDS_URL
+    value: "{{opensearch.dashboards_url}}"
+  - name: OPENSEARCH_URL
+    value: "{{opensearch.url}}"
+  - name: OPENSEARCH_USERNAME
+    value: "{{opensearch.username}}"
+secrets:
+  - name: opensearch.password
+    env: OPENSEARCH_PASSWORD
+    example: your_opensearch_password
+tools:
+  - name: opensearch_test
+  - name: opensearch_cluster_health
+  - name: opensearch_list_indices
+  - name: opensearch_list_index_patterns
+  - name: opensearch_get_mapping
+  - name: opensearch_discover_fields
+  - name: opensearch_index_settings
+  - name: opensearch_search
+  - name: opensearch_count
+  - name: opensearch_ppl
+  - name: opensearch_explain
+  - name: opensearch_terms
+  - name: opensearch_multi_terms
+  - name: opensearch_histogram
+  - name: opensearch_stats
+  - name: opensearch_compare
+  - name: opensearch_api
+metadata:
+  category: monitoring
+  tags:
+    - siem
+    - logs
+    - blue-team
+    - soc
+  license: MIT
+  owner: bunnyiesart

--- a/graylog-mcp/README.md
+++ b/graylog-mcp/README.md
@@ -42,13 +42,13 @@ docker run -i --rm --network host \
 
 | Tool | Description |
 |---|---|
-| `search_relative` | Search messages with relative time range |
-| `search_absolute` | Search messages with absolute time range |
-| `search_keyword` | Search messages with natural language time range |
-| `get_message` | Retrieve a specific message by ID |
-| `list_streams` | List all streams |
-| `get_stream` | Get stream details |
-| `search_events` | Search alert events |
-| `list_event_definitions` | List alert/event definitions |
-| `system_overview` | Graylog system info |
-| `list_inputs` | List configured inputs |
+| `graylog_search_relative` | Search messages with relative time range |
+| `graylog_search_absolute` | Search messages with absolute time range |
+| `graylog_search_keyword` | Search messages with natural language time range |
+| `graylog_get_message` | Retrieve a specific message by ID |
+| `graylog_list_streams` | List all streams |
+| `graylog_get_stream` | Get stream details |
+| `graylog_search_events` | Search alert events |
+| `graylog_list_event_definitions` | List alert/event definitions |
+| `graylog_system_overview` | Graylog system info |
+| `graylog_list_inputs` | List configured inputs |

--- a/graylog-mcp/server.py
+++ b/graylog-mcp/server.py
@@ -32,7 +32,7 @@ def _client() -> httpx.Client:
 # ── Search ─────────────────────────────────────────────────────────────────
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_search_relative")
 def search_relative(
     query: str,
     range_seconds: int = 300,
@@ -60,7 +60,7 @@ def search_relative(
         return r.json()
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_search_absolute")
 def search_absolute(
     query: str,
     from_time: str,
@@ -90,7 +90,7 @@ def search_absolute(
         return r.json()
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_search_keyword")
 def search_keyword(
     query: str,
     keyword: str = "last 1 hour",
@@ -118,7 +118,7 @@ def search_keyword(
         return r.json()
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_get_message")
 def get_message(message_id: str, index: str) -> dict:
     """Retrieve a specific message by ID.
 
@@ -135,7 +135,7 @@ def get_message(message_id: str, index: str) -> dict:
 # ── Streams ────────────────────────────────────────────────────────────────
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_list_streams")
 def list_streams() -> dict:
     """List all streams configured in Graylog."""
     with _client() as c:
@@ -144,7 +144,7 @@ def list_streams() -> dict:
         return r.json()
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_get_stream")
 def get_stream(stream_id: str) -> dict:
     """Get details for a specific stream.
 
@@ -160,7 +160,7 @@ def get_stream(stream_id: str) -> dict:
 # ── Alerts / Events ───────────────────────────────────────────────────────
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_search_events")
 def search_events(
     query: str = "",
     timerange_from: int = 3600,
@@ -189,7 +189,7 @@ def search_events(
         return r.json()
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_list_event_definitions")
 def list_event_definitions() -> dict:
     """List all event/alert definitions configured in Graylog."""
     with _client() as c:
@@ -201,7 +201,7 @@ def list_event_definitions() -> dict:
 # ── System ─────────────────────────────────────────────────────────────────
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_system_overview")
 def system_overview() -> dict:
     """Get Graylog system overview (version, cluster, status)."""
     with _client() as c:
@@ -210,7 +210,7 @@ def system_overview() -> dict:
         return r.json()
 
 
-@mcp.tool()
+@mcp.tool(name="graylog_list_inputs")
 def list_inputs() -> dict:
     """List all configured inputs in Graylog."""
     with _client() as c:


### PR DESCRIPTION
## Summary
- **catalog:** add `opensearch.yaml` (`bunnyiesart/mcp-opensearch`) — 17 tools, official OpenSearch org logo, `dashboards_url`/`url`/`username` config + `OPENSEARCH_PASSWORD` secret. `verify_ssl` deliberately omitted: a boolean checkbox can't express "true when absent", so an untouched box would silently disable TLS verification.
- **catalog/iris.yaml:** add the missing `tools:` allowlist (10 tools) — the Toolkit was showing "Tools (0)".
- **graylog:** prefix all 10 tool names with `graylog_` so origin is unambiguous behind the MCP gateway (`server.py` decorators, catalog allowlist, README table). Function names unchanged.
- **README:** document opensearch under *Recommended External MCPs* and in the catalog-bundle callout.

## Notes
- graylog tool prefixing is a **breaking change** for anyone pinned to the bare names — shipped without an alias window.
- The graylog image (`ghcr.io/gabrielbelli/graylog-mcp`) still needs a rebuild+push for the renamed tools to take effect, then `./publish-catalog`.

Verified: `server.py` parses; server tool names == catalog allowlist (exact diff match).